### PR TITLE
PLAT-7018 Allow rewrite batches for replace and duplicate statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,6 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
                     <version>${logback.version}</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.openjdk.jmh</groupId>

--- a/src/main/java/com/singlestore/jdbc/Statement.java
+++ b/src/main/java/com/singlestore/jdbc/Statement.java
@@ -15,7 +15,6 @@ import com.singlestore.jdbc.client.result.Result;
 import com.singlestore.jdbc.export.ExceptionFactory;
 import com.singlestore.jdbc.message.client.QueryPacket;
 import com.singlestore.jdbc.message.server.OkPacket;
-import com.singlestore.jdbc.util.ClientParser;
 import com.singlestore.jdbc.util.NativeSql;
 import com.singlestore.jdbc.util.constants.ColumnFlags;
 import com.singlestore.jdbc.util.constants.ServerStatus;
@@ -935,20 +934,6 @@ public class Statement implements java.sql.Statement {
         con.getContext(),
         ColumnFlags.AUTO_INCREMENT | ColumnFlags.UNSIGNED,
         resultSetType);
-  }
-
-  protected boolean checkIfInsertDuplicateCommand(String sql) {
-    if (isInsertDuplicate == null) {
-      if (sql == null) {
-        isInsertDuplicate = false;
-      } else {
-        ClientParser parser =
-            ClientParser.parameterParts(
-                sql, (con.getContext().getServerStatus() & ServerStatus.NO_BACKSLASH_ESCAPES) > 0);
-        isInsertDuplicate = parser.isInsertDuplicate();
-      }
-    }
-    return isInsertDuplicate;
   }
 
   /**

--- a/src/main/java/com/singlestore/jdbc/client/impl/StandardClient.java
+++ b/src/main/java/com/singlestore/jdbc/client/impl/StandardClient.java
@@ -406,7 +406,7 @@ public class StandardClient implements Client, AutoCloseable {
       if (timeOut) {
         throw exceptionFactory
             .withSql(message.description())
-            .create("Socket error: query timed out", "08000", ioException);
+            .create("Query execution was interrupted", "70100", ioException);
       } else {
         throw exceptionFactory
             .withSql(message.description())
@@ -497,7 +497,7 @@ public class StandardClient implements Client, AutoCloseable {
         results.add(null);
         // read remaining results
         perMsgCounter++;
-        for (; perMsgCounter < responseMsg[readCounter - 1]; perMsgCounter++) {
+        for (; readCounter > 0 && perMsgCounter < responseMsg[readCounter - 1]; perMsgCounter++) {
           try {
             results.addAll(
                 readResponse(
@@ -594,7 +594,7 @@ public class StandardClient implements Client, AutoCloseable {
   private void checkCancelTimeout() throws SQLException {
     if (timeOut) {
       SQLException cause =
-          exceptionFactory.create("Connection is closed due to query timed out", "08000", 1220);
+          exceptionFactory.create("Query execution was interrupted", "70100", 1220);
       timeOut = false;
       throw cause;
     }
@@ -886,7 +886,7 @@ public class StandardClient implements Client, AutoCloseable {
       if (timeOut) {
         throw exceptionFactory
             .withSql(message.description())
-            .create("Socket error: query timed out", "08000", ioException);
+            .create("Query execution was interrupted", "70100", ioException);
       } else {
         throw exceptionFactory
             .withSql(message.description())
@@ -903,7 +903,7 @@ public class StandardClient implements Client, AutoCloseable {
   protected void checkNotClosed() throws SQLException {
     if (closed) {
       if (timeOut) {
-        throw exceptionFactory.create("Connection is closed due to query timed out", "08000", 1220);
+        throw exceptionFactory.create("Query execution was interrupted", "70100", 1220);
       } else {
         throw exceptionFactory.create("Connection is closed", "08000", 1220);
       }

--- a/src/main/java/com/singlestore/jdbc/client/util/Parameter.java
+++ b/src/main/java/com/singlestore/jdbc/client/util/Parameter.java
@@ -65,6 +65,13 @@ public interface Parameter {
   int getBinaryEncodeType();
 
   /**
+   * Approximate length in bytes.
+   *
+   * @return value length in bytes
+   */
+  int getApproximateTextProtocolLength() throws IOException, SQLException;
+
+  /**
    * is parameter null
    *
    * @return is null

--- a/src/main/java/com/singlestore/jdbc/codec/NonNullParameter.java
+++ b/src/main/java/com/singlestore/jdbc/codec/NonNullParameter.java
@@ -32,4 +32,9 @@ public class NonNullParameter<T> extends Parameter<T> {
   public boolean isNull() {
     return false;
   }
+
+  @Override
+  public int getApproximateTextProtocolLength() throws SQLException {
+    return 0;
+  }
 }

--- a/src/main/java/com/singlestore/jdbc/codec/Parameter.java
+++ b/src/main/java/com/singlestore/jdbc/codec/Parameter.java
@@ -76,6 +76,11 @@ public class Parameter<T> implements com.singlestore.jdbc.client.util.Parameter 
     return codec.getBinaryEncodeType();
   }
 
+  @Override
+  public int getApproximateTextProtocolLength() throws SQLException {
+    return (codec == null || value == null) ? 0 : codec.getApproximateTextProtocolLength(value);
+  }
+
   public boolean isNull() {
     return value == null;
   }

--- a/src/main/java/com/singlestore/jdbc/message/client/ExecutePacket.java
+++ b/src/main/java/com/singlestore/jdbc/message/client/ExecutePacket.java
@@ -13,7 +13,6 @@ import com.singlestore.jdbc.client.util.Parameters;
 import com.singlestore.jdbc.export.Prepare;
 import com.singlestore.jdbc.message.ClientMessage;
 import com.singlestore.jdbc.message.server.PrepareResultPacket;
-import com.singlestore.jdbc.plugin.codec.ByteArrayCodec;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
@@ -53,16 +52,7 @@ public final class ExecutePacket implements RedoableWithPrepareClientMessage {
   }
 
   @Override
-  public void ensureReplayable(Context context) throws IOException, SQLException {
-    int parameterCount = parameters.size();
-    for (int i = 0; i < parameterCount; i++) {
-      Parameter p = parameters.get(i);
-      if (!p.isNull() && p.canEncodeLongData()) {
-        this.parameters.set(
-            i, new com.singlestore.jdbc.codec.Parameter<>(ByteArrayCodec.INSTANCE, p.encodeData()));
-      }
-    }
-  }
+  public void ensureReplayable(Context context) throws IOException, SQLException {}
 
   /**
    * COM_STMT_EXECUTE packet

--- a/src/main/java/com/singlestore/jdbc/message/client/QueryWithParametersPacket.java
+++ b/src/main/java/com/singlestore/jdbc/message/client/QueryWithParametersPacket.java
@@ -7,10 +7,8 @@ package com.singlestore.jdbc.message.client;
 
 import com.singlestore.jdbc.client.Context;
 import com.singlestore.jdbc.client.socket.Writer;
-import com.singlestore.jdbc.client.util.Parameter;
 import com.singlestore.jdbc.client.util.Parameters;
 import com.singlestore.jdbc.message.ClientMessage;
-import com.singlestore.jdbc.plugin.codec.ByteArrayCodec;
 import com.singlestore.jdbc.util.ClientParser;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,16 +41,7 @@ public final class QueryWithParametersPacket implements RedoableClientMessage {
   }
 
   @Override
-  public void ensureReplayable(Context context) throws IOException, SQLException {
-    int parameterCount = parameters.size();
-    for (int i = 0; i < parameterCount; i++) {
-      Parameter p = parameters.get(i);
-      if (!p.isNull() && p.canEncodeLongData()) {
-        this.parameters.set(
-            i, new com.singlestore.jdbc.codec.Parameter<>(ByteArrayCodec.INSTANCE, p.encodeData()));
-      }
-    }
-  }
+  public void ensureReplayable(Context context) throws IOException, SQLException {}
 
   public void saveParameters() {
     this.parameters = this.parameters.clone();

--- a/src/main/java/com/singlestore/jdbc/message/client/RewriteQueryMultiPacket.java
+++ b/src/main/java/com/singlestore/jdbc/message/client/RewriteQueryMultiPacket.java
@@ -9,10 +9,12 @@ import com.singlestore.jdbc.client.Context;
 import com.singlestore.jdbc.client.socket.Writer;
 import com.singlestore.jdbc.client.util.Parameter;
 import com.singlestore.jdbc.client.util.Parameters;
-import com.singlestore.jdbc.plugin.codec.ByteArrayCodec;
-import com.singlestore.jdbc.util.ClientParser;
+import com.singlestore.jdbc.util.RewriteClientParser;
+import com.singlestore.jdbc.util.log.Loggers;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Query with parameters packet used for insert batch with rewrite option {@link
@@ -20,9 +22,9 @@ import java.sql.SQLException;
  */
 public class RewriteQueryMultiPacket implements RedoableClientMessage {
 
-  private static final int PARAMETER_LENGTH = 1024;
-  private final ClientParser parser;
-  private Parameters parameters;
+  private final Configuration config;
+  private final RewriteClientParser parser;
+  private List<Parameters> batchParameters;
   private final int paramCount;
 
   /**
@@ -30,66 +32,150 @@ public class RewriteQueryMultiPacket implements RedoableClientMessage {
    *
    * @param paramCount original query param count
    * @param parser command parser result
-   * @param parameters parameters
+   * @param batchParameters batch parameters
    */
-  public RewriteQueryMultiPacket(int paramCount, ClientParser parser, Parameters parameters) {
+  public RewriteQueryMultiPacket(
+      Configuration config,
+      int paramCount,
+      RewriteClientParser parser,
+      List<Parameters> batchParameters) {
+    this.config = config;
     this.paramCount = paramCount;
     this.parser = parser;
-    this.parameters = parameters;
+    this.batchParameters = batchParameters;
   }
 
   @Override
-  public void ensureReplayable(Context context) throws IOException, SQLException {
-    int parameterCount = parameters.size();
-    for (int i = 0; i < parameterCount; i++) {
-      Parameter p = parameters.get(i);
-      if (!p.isNull() && p.canEncodeLongData()) {
-        this.parameters.set(
-            i, new com.singlestore.jdbc.codec.Parameter<>(ByteArrayCodec.INSTANCE, p.encodeData()));
-      }
-    }
-  }
+  public void ensureReplayable(Context context) {}
 
   public void saveParameters() {
-    this.parameters = this.parameters.clone();
+    List<Parameters> clonedBatches = new ArrayList<>();
+    for (Parameters parameters : batchParameters) {
+      clonedBatches.add(parameters.clone());
+    }
+    this.batchParameters = clonedBatches;
   }
 
   @Override
   public int encode(Writer encoder, Context context) throws IOException, SQLException {
     int packetsSize = 0;
+    int currentIndex = 0;
+    int totalParameterList = batchParameters.size();
+    do {
+      currentIndex = sendRewriteCmd(encoder, context, currentIndex);
+      packetsSize++; // number of flushes
+      if (Thread.currentThread().isInterrupted()) {
+        throw new SQLException("Interrupted during batch", "70", -1);
+      }
+
+    } while (currentIndex < totalParameterList);
+    return packetsSize;
+  }
+
+  /**
+   * Client side PreparedStatement.executeBatch values rewritten (concatenate value params according
+   * to max_allowed_packet)
+   *
+   * @param currentIndex currentIndex
+   * @return current index
+   * @throws IOException if connection fail
+   */
+  private int sendRewriteCmd(Writer encoder, Context context, int currentIndex)
+      throws IOException, SQLException {
+    int batchIndex = currentIndex;
+
     encoder.initPacket();
     encoder.writeByte(0x03);
-    if (parser.getParamPositions().size() == 0) {
-      encoder.writeBytes(parser.getQuery());
-    } else {
-      int pos = 0;
-      int lastParamPos = parser.getParamPositions().get(parser.getParamPositions().size() - 1) + 1;
-      int paramPosIdx = 0;
-      int paramPos;
-      for (int i = 0; i < parser.getParamPositions().size(); i++) {
-        if (encoder.throwMaxAllowedLength(encoder.pos() + paramCount * PARAMETER_LENGTH)
-            && paramPosIdx != 0
-            && paramPosIdx % paramCount == 0) {
-          encoder.writeBytes(
-              parser.getQuery(), lastParamPos, parser.getQuery().length - lastParamPos);
-          encoder.flush();
-          packetsSize++;
-          encoder.initPacket();
-          encoder.writeByte(0x03);
-          pos = 0;
-          paramPosIdx = 0;
+    Parameters parameters = batchParameters.get(batchIndex++);
+    List<byte[]> queryParts = parser.getQueryParts();
+
+    byte[] firstPart = queryParts.get(0);
+    byte[] secondPart = queryParts.get(1);
+
+    encoder.writeBytes(firstPart, 0, firstPart.length);
+    encoder.writeBytes(secondPart, 0, secondPart.length);
+
+    int packetLength = parser.getQueryPartsLength() + getApproximateParametersLength(parameters);
+
+    for (int i = 0; i < paramCount; i++) {
+      parameters.get(i).encodeText(encoder, context);
+      encoder.writeBytes(queryParts.get(i + 2));
+    }
+
+    if (parser.isQueryMultiValuesRewritable()) {
+      Loggers.getLogger(RewriteQueryMultiPacket.class)
+          .debug("execute multi values rewrite batch query");
+      while (batchIndex < batchParameters.size()) {
+        parameters = batchParameters.get(batchIndex);
+
+        // check packet length so to separate in multiple packet
+        packetLength += getApproximateParametersLength(parameters);
+        if (!encoder.throwMaxAllowedLength(packetLength)) {
+          encoder.writeByte((byte) ',');
+          encoder.writeBytes(secondPart, 0, secondPart.length);
+
+          for (int i = 0; i < paramCount; i++) {
+            parameters.get(i).encodeText(encoder, context);
+            byte[] addPart = queryParts.get(i + 2);
+            encoder.writeBytes(addPart, 0, addPart.length);
+          }
+          batchIndex++;
+        } else {
+          Loggers.getLogger(RewriteQueryMultiPacket.class)
+              .debug(
+                  "split multi values rewrite batch query on {} batch with size {}",
+                  batchIndex,
+                  packetLength);
+          break;
         }
-        paramPos = parser.getParamPositions().get(paramPosIdx);
-        encoder.writeBytes(parser.getQuery(), pos, paramPos - pos);
-        pos = paramPos + 1;
-        parameters.get(i).encodeText(encoder, context);
-        paramPosIdx++;
       }
-      encoder.writeBytes(parser.getQuery(), lastParamPos, parser.getQuery().length - lastParamPos);
+      encoder.writeBytes(queryParts.get(paramCount + 2));
+    } else {
+      encoder.writeBytes(queryParts.get(paramCount + 2));
+      while (batchIndex < batchParameters.size()) {
+        if (!config.allowMultiQueries()) {
+          break;
+        }
+        parameters = batchParameters.get(batchIndex);
+        // check packet length so to separate in multiple packet
+        packetLength +=
+            getApproximateParametersLength(parameters) + parser.getQueryPartsLength() + 1;
+        if (!encoder.throwMaxAllowedLength(packetLength)) {
+          encoder.writeByte((byte) ';');
+          encoder.writeBytes(firstPart, 0, firstPart.length);
+          encoder.writeBytes(secondPart, 0, secondPart.length);
+          for (int i = 0; i < paramCount; i++) {
+            parameters.get(i).encodeText(encoder, context);
+            encoder.writeBytes(queryParts.get(i + 2));
+          }
+          encoder.writeBytes(queryParts.get(paramCount + 2));
+          batchIndex++;
+        } else {
+          Loggers.getLogger(RewriteQueryMultiPacket.class)
+              .debug(
+                  "split  multi queries command on {} batch with size {}",
+                  batchIndex,
+                  packetLength);
+          break;
+        }
+      }
     }
     encoder.flush();
-    packetsSize++;
-    return packetsSize;
+    return batchIndex;
+  }
+
+  private int getApproximateParametersLength(Parameters parameters)
+      throws IOException, SQLException {
+    int parameterLength = 0;
+    for (int i = 0; i < paramCount; i++) {
+      Parameter parameter = parameters.get(i);
+      int paramSize = parameter.getApproximateTextProtocolLength();
+      if (paramSize == -1) {
+        return 1024; // default approximate
+      }
+      parameterLength += paramSize;
+    }
+    return parameterLength;
   }
 
   public int batchUpdateLength() {

--- a/src/main/java/com/singlestore/jdbc/plugin/Codec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/Codec.java
@@ -48,6 +48,14 @@ public interface Codec<T> {
   boolean canEncode(Object value);
 
   /**
+   * Approximate length in bytes.
+   *
+   * @param value to calculate
+   * @return value length in bytes
+   */
+  int getApproximateTextProtocolLength(Object value) throws SQLException;
+
+  /**
    * Decode from a mysql packet text encoded a value to codec java type
    *
    * @param buffer mysql packet buffer

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BigDecimalCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BigDecimalCodec.java
@@ -56,6 +56,11 @@ public class BigDecimalCodec implements Codec<BigDecimal> {
   }
 
   @Override
+  public int getApproximateTextProtocolLength(Object value) {
+    return canEncode(value) ? ((BigDecimal) value).toPlainString().getBytes().length : -1;
+  }
+
+  @Override
   @SuppressWarnings("fallthrough")
   public BigDecimal decodeText(
       ReadableByteBuf buf, MutableInt length, ColumnDecoder column, Calendar cal)

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BigIntegerCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BigIntegerCodec.java
@@ -56,6 +56,11 @@ public class BigIntegerCodec implements Codec<BigInteger> {
   }
 
   @Override
+  public int getApproximateTextProtocolLength(Object value) {
+    return canEncode(value) ? ((BigInteger) value).toByteArray().length : -1;
+  }
+
+  @Override
   @SuppressWarnings("fallthrough")
   public BigInteger decodeText(
       ReadableByteBuf buf, MutableInt length, ColumnDecoder column, Calendar cal)

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BitSetCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BitSetCodec.java
@@ -65,6 +65,11 @@ public class BitSetCodec implements Codec<BitSet> {
   }
 
   @Override
+  public int getApproximateTextProtocolLength(Object value) {
+    return canEncode(value) ? ((BitSet) value).length() : -1;
+  }
+
+  @Override
   public void encodeText(Writer encoder, Context context, Object value, Calendar cal, Long length)
       throws IOException {
     byte[] bytes = ((BitSet) value).toByteArray();

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BlobCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BlobCodec.java
@@ -51,6 +51,11 @@ public class BlobCodec implements Codec<Blob> {
   }
 
   @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? (int) ((Blob) value).length() : -1;
+  }
+
+  @Override
   @SuppressWarnings("fallthrough")
   public Blob decodeText(ReadableByteBuf buf, MutableInt length, ColumnDecoder column, Calendar cal)
       throws SQLDataException {

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BooleanCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BooleanCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -53,6 +54,11 @@ public class BooleanCodec implements Codec<Boolean> {
 
   public boolean canEncode(Object value) {
     return value instanceof Boolean;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 1;
   }
 
   public Boolean decodeText(

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ByteArrayCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ByteArrayCodec.java
@@ -15,6 +15,7 @@ import com.singlestore.jdbc.plugin.Codec;
 import com.singlestore.jdbc.util.constants.ServerStatus;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -47,6 +48,11 @@ public class ByteArrayCodec implements Codec<byte[]> {
 
   public boolean canEncode(Object value) {
     return value instanceof byte[];
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? ((byte[]) value).length * 2 : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ByteCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ByteCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -74,6 +75,11 @@ public class ByteCodec implements Codec<Byte> {
 
   public boolean canEncode(Object value) {
     return value instanceof Byte;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).length() : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ClobCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ClobCodec.java
@@ -52,6 +52,11 @@ public class ClobCodec implements Codec<Clob> {
   }
 
   @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? (int) ((Clob) value).length() : -1;
+  }
+
+  @Override
   public Clob decodeText(ReadableByteBuf buf, MutableInt length, ColumnDecoder column, Calendar cal)
       throws SQLDataException {
     return getClob(buf, length, column);

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/DateCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/DateCodec.java
@@ -15,6 +15,7 @@ import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.Date;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.EnumSet;
@@ -48,6 +49,11 @@ public class DateCodec implements Codec<Date> {
 
   public boolean canEncode(Object value) {
     return value instanceof Date || java.util.Date.class.equals(value.getClass());
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 16;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/DoubleCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/DoubleCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -52,6 +53,11 @@ public class DoubleCodec implements Codec<Double> {
 
   public boolean canEncode(Object value) {
     return value instanceof Double;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/DurationCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/DurationCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Calendar;
 import java.util.EnumSet;
@@ -44,6 +45,11 @@ public class DurationCodec implements Codec<Duration> {
 
   public boolean canEncode(Object value) {
     return value instanceof Duration;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/FloatCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/FloatCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -52,6 +53,11 @@ public class FloatCodec implements Codec<Float> {
 
   public boolean canEncode(Object value) {
     return value instanceof Float;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/InstantCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/InstantCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -52,6 +53,11 @@ public class InstantCodec implements Codec<Instant> {
 
   public boolean canEncode(Object value) {
     return value instanceof Instant;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/IntCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/IntCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -53,6 +54,11 @@ public class IntCodec implements Codec<Integer> {
 
   public boolean canEncode(Object value) {
     return value instanceof Integer;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/LineStringCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/LineStringCodec.java
@@ -15,6 +15,7 @@ import com.singlestore.jdbc.plugin.Codec;
 import com.singlestore.jdbc.type.LineString;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 
 public class LineStringCodec implements Codec<LineString> {
@@ -31,6 +32,11 @@ public class LineStringCodec implements Codec<LineString> {
 
   public boolean canEncode(Object value) {
     return value instanceof LineString;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/LocalDateCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/LocalDateCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -68,6 +69,11 @@ public class LocalDateCodec implements Codec<LocalDate> {
 
   public boolean canEncode(Object value) {
     return value instanceof LocalDate;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 10;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/LocalDateTimeCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/LocalDateTimeCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -104,6 +105,11 @@ public class LocalDateTimeCodec implements Codec<LocalDateTime> {
 
   public boolean canEncode(Object value) {
     return value instanceof LocalDateTime;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 26;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/LocalTimeCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/LocalTimeCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -97,6 +98,11 @@ public class LocalTimeCodec implements Codec<LocalTime> {
 
   public boolean canEncode(Object value) {
     return value instanceof LocalTime;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 15;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/LongCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/LongCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -54,6 +55,11 @@ public class LongCodec implements Codec<Long> {
 
   public boolean canEncode(Object value) {
     return value instanceof Long;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/OffsetDateTimeCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/OffsetDateTimeCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
@@ -52,6 +53,11 @@ public class OffsetDateTimeCodec implements Codec<OffsetDateTime> {
 
   public boolean canEncode(Object value) {
     return value instanceof OffsetDateTime;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 15;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/PointCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/PointCodec.java
@@ -15,6 +15,7 @@ import com.singlestore.jdbc.plugin.Codec;
 import com.singlestore.jdbc.type.Point;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 
 public class PointCodec implements Codec<Point> {
@@ -31,6 +32,11 @@ public class PointCodec implements Codec<Point> {
 
   public boolean canEncode(Object value) {
     return value instanceof Point;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/PolygonCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/PolygonCodec.java
@@ -15,6 +15,7 @@ import com.singlestore.jdbc.plugin.Codec;
 import com.singlestore.jdbc.type.Polygon;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 
 public class PolygonCodec implements Codec<Polygon> {
@@ -31,6 +32,11 @@ public class PolygonCodec implements Codec<Polygon> {
 
   public boolean canEncode(Object value) {
     return value instanceof Polygon;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ReaderCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ReaderCodec.java
@@ -19,6 +19,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -81,6 +82,11 @@ public class ReaderCodec implements Codec<Reader> {
 
   public boolean canEncode(Object value) {
     return value instanceof Reader;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ShortCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ShortCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -49,6 +50,11 @@ public class ShortCodec implements Codec<Short> {
 
   public boolean canEncode(Object value) {
     return value instanceof Short;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).getBytes().length : -1;
   }
 
   public String className() {

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/StreamCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/StreamCodec.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -90,6 +91,11 @@ public class StreamCodec implements Codec<InputStream> {
 
   public boolean canEncode(Object value) {
     return value instanceof InputStream;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return -1;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/StringCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/StringCodec.java
@@ -16,6 +16,7 @@ import com.singlestore.jdbc.util.constants.ServerStatus;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -62,6 +63,11 @@ public class StringCodec implements Codec<String> {
 
   public boolean canEncode(Object value) {
     return value instanceof String;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return canEncode(value) ? String.valueOf(value).length() * 3 : -1;
   }
 
   public String decodeText(

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/TimeCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/TimeCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -48,6 +49,11 @@ public class TimeCodec implements Codec<Time> {
 
   public boolean canEncode(Object value) {
     return value instanceof Time;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 15;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/TimestampCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/TimestampCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -48,6 +49,11 @@ public class TimestampCodec implements Codec<Timestamp> {
 
   public boolean canEncode(Object value) {
     return value instanceof Timestamp;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 27;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/UuidCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/UuidCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.UUID;
@@ -37,6 +38,11 @@ public class UuidCodec implements Codec<UUID> {
 
   public boolean canEncode(Object value) {
     return value instanceof UUID;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 40;
   }
 
   public UUID decodeText(

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ZonedDateTimeCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ZonedDateTimeCodec.java
@@ -14,6 +14,7 @@ import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
@@ -49,6 +50,11 @@ public class ZonedDateTimeCodec implements Codec<ZonedDateTime> {
 
   public boolean canEncode(Object value) {
     return value instanceof ZonedDateTime;
+  }
+
+  @Override
+  public int getApproximateTextProtocolLength(Object value) throws SQLException {
+    return 27;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/util/ClientParser.java
+++ b/src/main/java/com/singlestore/jdbc/util/ClientParser.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (c) 2012-2014 Monty Program Ab
-// Copyright (c) 2015-2023 MariaDB Corporation Ab
-// Copyright (c) 2021-2023 SingleStore, Inc.
+// Copyright (c) 2015-2021 MariaDB Corporation Ab
+// Copyright (c) 2021 SingleStore, Inc.
 
 package com.singlestore.jdbc.util;
 
@@ -15,43 +15,23 @@ public final class ClientParser implements PrepareResult {
   private final byte[] query;
   private final List<Integer> paramPositions;
   private final int paramCount;
-  private final boolean isInsert;
-  private final boolean isInsertDuplicate;
+  private final boolean isRewriteBatchedApplicable;
 
   private ClientParser(
-      String sql,
-      byte[] query,
-      List<Integer> paramPositions,
-      boolean isInsert,
-      boolean isInsertDuplicate) {
+      String sql, byte[] query, List<Integer> paramPositions, boolean isRewriteBatchedApplicable) {
     this.sql = sql;
     this.query = query;
     this.paramPositions = paramPositions;
     this.paramCount = paramPositions.size();
-    this.isInsert = isInsert;
-    this.isInsertDuplicate = isInsertDuplicate;
+    this.isRewriteBatchedApplicable = isRewriteBatchedApplicable;
   }
 
-  // isRewriteBatchedApplicable returns true if the parameter sql
-  // represents INSERT operation without 'ON DUPLICATE KEY UPDATE' clause
-  //
   public boolean isRewriteBatchedApplicable() {
-    return isInsert && !isInsertDuplicate;
+    return isRewriteBatchedApplicable;
   }
 
-  public boolean isInsert() {
-    return isInsert;
-  }
-
-  public boolean isInsertDuplicate() {
-    return isInsertDuplicate;
-  }
   /**
-   * Separate query in a String list and set flag isQueryMultipleRewritable. The resulting string
-   * list is separed by ? that are not in comments. isQueryMultipleRewritable flag is set if query
-   * can be rewrite in one query (all case but if using "-- comment"). example for query : "INSERT
-   * INTO tableName(id, name) VALUES (?, ?)" result list will be : {"INSERT INTO tableName(id, name)
-   * VALUES (", ", ", ")"}
+   * Parse prepared statement query.
    *
    * @param queryString query
    * @param noBackslashEscapes escape mode
@@ -64,7 +44,7 @@ public final class ClientParser implements PrepareResult {
     byte lastChar = 0x00;
     boolean singleQuotes = false;
     boolean isInsert = false;
-    boolean isInsertDupplicate = false;
+    boolean isReplace = false;
 
     byte[] query = queryString.getBytes(StandardCharsets.UTF_8);
     int queryLength = query.length;
@@ -133,7 +113,7 @@ public final class ClientParser implements PrepareResult {
           break;
         case (byte) 'I':
         case (byte) 'i':
-          if (state == LexState.Normal && !isInsert) {
+          if (state == LexState.Normal && !isInsert && !isReplace) {
             if (i + 6 < queryLength
                 && (query[i + 1] == (byte) 'n' || query[i + 1] == (byte) 'N')
                 && (query[i + 2] == (byte) 's' || query[i + 2] == (byte) 'S')
@@ -151,30 +131,27 @@ public final class ClientParser implements PrepareResult {
             }
           }
           break;
-        case (byte) 'D':
-        case (byte) 'd':
-          if (isInsert && state == ClientParser.LexState.Normal) {
-            if (i + 9 < queryLength
-                && (query[i + 1] == (byte) 'u' || query[i + 1] == (byte) 'U')
+        case (byte) 'R':
+        case (byte) 'r':
+          if (state == LexState.Normal && !isInsert && !isReplace) {
+            if (i + 7 < queryLength
+                && (query[i + 1] == (byte) 'e' || query[i + 1] == (byte) 'E')
                 && (query[i + 2] == (byte) 'p' || query[i + 2] == (byte) 'P')
                 && (query[i + 3] == (byte) 'l' || query[i + 3] == (byte) 'L')
-                && (query[i + 4] == (byte) 'i' || query[i + 4] == (byte) 'I')
+                && (query[i + 4] == (byte) 'a' || query[i + 4] == (byte) 'A')
                 && (query[i + 5] == (byte) 'c' || query[i + 5] == (byte) 'C')
-                && (query[i + 6] == (byte) 'a' || query[i + 6] == (byte) 'A')
-                && (query[i + 7] == (byte) 't' || query[i + 7] == (byte) 'T')
-                && (query[i + 8] == (byte) 'e' || query[i + 8] == (byte) 'E')) {
+                && (query[i + 6] == (byte) 'e' || query[i + 6] == (byte) 'E')) {
               if (i > 0 && (query[i - 1] > ' ' && "();><=-+,".indexOf(query[i - 1]) == -1)) {
                 break;
               }
-              if (query[i + 9] > ' ' && "();><=-+,".indexOf(query[i + 9]) == -1) {
+              if (query[i + 7] > ' ' && "();><=-+,".indexOf(query[i + 6]) == -1) {
                 break;
               }
-              i += 9;
-              isInsertDupplicate = true;
+              i += 6;
+              isReplace = true;
             }
           }
           break;
-
         case (byte) '\\':
           if (noBackslashEscapes) {
             break;
@@ -198,7 +175,7 @@ public final class ClientParser implements PrepareResult {
       }
       lastChar = car;
     }
-    return new ClientParser(queryString, query, paramPositions, isInsert, isInsertDupplicate);
+    return new ClientParser(queryString, query, paramPositions, isInsert || isReplace);
   }
 
   public String getSql() {

--- a/src/main/java/com/singlestore/jdbc/util/RewriteClientParser.java
+++ b/src/main/java/com/singlestore/jdbc/util/RewriteClientParser.java
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (c) 2012-2014 Monty Program Ab
+// Copyright (c) 2015-2024 MariaDB Corporation Ab
+// Copyright (c) 2021-2024 SingleStore, Inc.
+
+package com.singlestore.jdbc.util;
+
+import com.singlestore.jdbc.util.ClientParser.LexState;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RewriteClientParser implements PrepareResult {
+
+  private final String sql;
+  private final List<byte[]> queryParts;
+  private final int paramCount;
+  private final int queryPartsLength;
+  private final boolean isQueryMultiValuesRewritable;
+
+  private RewriteClientParser(
+      String sql,
+      List<byte[]> queryParts,
+      int queryPartsLength,
+      boolean isQueryMultiValuesRewritable) {
+    this.sql = sql;
+    this.queryParts = queryParts;
+    this.queryPartsLength = queryPartsLength;
+    this.isQueryMultiValuesRewritable = isQueryMultiValuesRewritable;
+    this.paramCount = queryParts.size() - 3;
+  }
+
+  /**
+   * Separate query in a String list and set flag isQueryMultiValuesRewritable The parameters "?"
+   * (not in comments) emplacements are to be known.
+   *
+   * <p>The only rewritten queries follow these notation: INSERT|REPLACE tbl_name [(col,...)]
+   * {VALUES} (...) [ ON DUPLICATE KEY UPDATE col=expr [, col=expr] ... ] With expr without
+   * parameter.
+   *
+   * <p>Query with LAST_INSERT_ID() will not be rewritten
+   *
+   * <p>INSERT ... SELECT will not be rewritten.
+   *
+   * <p>String list :
+   *
+   * <ul>
+   *   <li>pre value part
+   *   <li>After value and first parameter part
+   *   <li>for each parameters :
+   *       <ul>
+   *         <li>part after parameter and before last parenthesis
+   *         <li>Last query part
+   *       </ul>
+   * </ul>
+   *
+   * <p>example : INSERT INTO TABLE(col1,col2,col3,col4, col5) VALUES (9, ?, 5, ?, 8) ON DUPLICATE
+   * KEY UPDATE col2=col2+10
+   *
+   * <ul>
+   *   <li>pre value part : INSERT INTO TABLE(col1,col2,col3,col4, col5) VALUES
+   *   <li>after value part : "(9 "
+   *   <li>part after parameter 1: ", 5," - ", 5," - ",8)"
+   *   <li>last part : ON DUPLICATE KEY UPDATE col2=col2+10
+   * </ul>
+   *
+   * <p>With 2 series of parameters, this query will be rewritten like [INSERT INTO
+   * TABLE(col1,col2,col3,col4, col5) VALUES][ (9, param0_1, 5, param0_2, 8)][, (9, param1_1, 5,
+   * param1_2, 8)][ ON DUPLICATE KEY UPDATE col2=col2+10]
+   *
+   * @param queryString query String
+   * @param noBackslashEscapes must backslash be escaped.
+   * @return List of query part.
+   */
+  public static RewriteClientParser rewritableParts(
+      String queryString, boolean noBackslashEscapes) {
+    boolean reWritablePrepare = true;
+    List<byte[]> partList = new ArrayList<>();
+    LexState state = LexState.Normal;
+    char lastChar = '\0';
+
+    StringBuilder sb = new StringBuilder();
+
+    String preValuePart1 = null;
+    String preValuePart2 = null;
+    String postValuePart = null;
+
+    boolean singleQuotes = false;
+
+    int isInParenthesis = 0;
+    boolean skipChar = false;
+    boolean isFirstChar = true;
+    boolean isInsert = false;
+    boolean isReplace = false;
+    boolean semicolon = false;
+    boolean hasParam = false;
+
+    char[] query = queryString.toCharArray();
+    int queryLength = query.length;
+    for (int i = 0; i < queryLength; i++) {
+
+      char car = query[i];
+      if (state == LexState.Escape
+          && !((car == '\'' && singleQuotes) || (car == '"' && !singleQuotes))) {
+        sb.append(car);
+        lastChar = car;
+        state = LexState.String;
+        continue;
+      }
+
+      switch (car) {
+        case '*':
+          if (state == LexState.Normal && lastChar == '/') {
+            state = LexState.SlashStarComment;
+          }
+          break;
+        case '/':
+          if (state == LexState.SlashStarComment && lastChar == '*') {
+            state = LexState.Normal;
+          }
+          break;
+
+        case '#':
+          if (state == LexState.Normal) {
+            state = LexState.EOLComment;
+          }
+          break;
+
+        case '-':
+          if (state == LexState.Normal && lastChar == '-') {
+            state = LexState.EOLComment;
+          }
+          break;
+
+        case '\n':
+          if (state == LexState.EOLComment) {
+            state = LexState.Normal;
+          }
+          break;
+
+        case '"':
+          if (state == LexState.Normal) {
+            state = LexState.String;
+            singleQuotes = false;
+          } else if (state == LexState.String && !singleQuotes) {
+            state = LexState.Normal;
+          } else if (state == LexState.Escape && !singleQuotes) {
+            state = LexState.String;
+          }
+          break;
+        case ';':
+          if (state == LexState.Normal) {
+            semicolon = true;
+          }
+          break;
+        case '\'':
+          if (state == LexState.Normal) {
+            state = LexState.String;
+            singleQuotes = true;
+          } else if (state == LexState.String && singleQuotes) {
+            state = LexState.Normal;
+          } else if (state == LexState.Escape && singleQuotes) {
+            state = LexState.String;
+          }
+          break;
+
+        case '\\':
+          if (noBackslashEscapes) {
+            break;
+          }
+          if (state == LexState.String) {
+            state = LexState.Escape;
+          }
+          break;
+
+        case '?':
+          if (state == LexState.Normal) {
+            hasParam = true;
+            if (preValuePart1 == null) {
+              preValuePart1 = sb.toString();
+              sb.setLength(0);
+            }
+            if (preValuePart2 == null) {
+              preValuePart2 = sb.toString();
+              sb.setLength(0);
+            } else {
+              if (postValuePart != null) {
+                // having parameters after the last ")" of value is not rewritable
+                reWritablePrepare = false;
+
+                // add part
+                sb.insert(0, postValuePart);
+                postValuePart = null;
+              }
+              partList.add(sb.toString().getBytes(StandardCharsets.UTF_8));
+              sb.setLength(0);
+            }
+
+            skipChar = true;
+          }
+          break;
+        case '`':
+          if (state == LexState.Backtick) {
+            state = LexState.Normal;
+          } else if (state == LexState.Normal) {
+            state = LexState.Backtick;
+          }
+          break;
+
+        case 's':
+        case 'S':
+          if (state == LexState.Normal
+              && postValuePart == null
+              && queryLength > i + 7
+              && (query[i + 1] == 'e' || query[i + 1] == 'E')
+              && (query[i + 2] == 'l' || query[i + 2] == 'L')
+              && (query[i + 3] == 'e' || query[i + 3] == 'E')
+              && (query[i + 4] == 'c' || query[i + 4] == 'C')
+              && (query[i + 5] == 't' || query[i + 5] == 'T')) {
+
+            // field/table name might contain 'select'
+            if (i > 0 && (query[i - 1] > ' ' && "();><=-+,".indexOf(query[i - 1]) == -1)) {
+              break;
+            }
+            if (query[i + 6] > ' ' && "();><=-+,".indexOf(query[i + 6]) == -1) {
+              break;
+            }
+
+            // SELECT queries, INSERT FROM SELECT not rewritable
+            reWritablePrepare = false;
+          }
+          break;
+        case 'v':
+        case 'V':
+          if (state == LexState.Normal
+              && preValuePart1 == null
+              && (lastChar == ')' || ((byte) lastChar <= 40))
+              && queryLength > i + 7
+              && (query[i + 1] == 'a' || query[i + 1] == 'A')
+              && (query[i + 2] == 'l' || query[i + 2] == 'L')
+              && (query[i + 3] == 'u' || query[i + 3] == 'U')
+              && (query[i + 4] == 'e' || query[i + 4] == 'E')
+              && (query[i + 5] == 's' || query[i + 5] == 'S')
+              && (query[i + 6] == '(' || ((byte) query[i + 6] <= 40))) {
+            sb.append(car);
+            sb.append(query[i + 1]);
+            sb.append(query[i + 2]);
+            sb.append(query[i + 3]);
+            sb.append(query[i + 4]);
+            sb.append(query[i + 5]);
+            i = i + 5;
+            preValuePart1 = sb.toString();
+            sb.setLength(0);
+            skipChar = true;
+          }
+          break;
+        case 'l':
+        case 'L':
+          if (state == LexState.Normal
+              && queryLength > i + 14
+              && (query[i + 1] == 'a' || query[i + 1] == 'A')
+              && (query[i + 2] == 's' || query[i + 2] == 'S')
+              && (query[i + 3] == 't' || query[i + 3] == 'T')
+              && query[i + 4] == '_'
+              && (query[i + 5] == 'i' || query[i + 5] == 'I')
+              && (query[i + 6] == 'n' || query[i + 6] == 'N')
+              && (query[i + 7] == 's' || query[i + 7] == 'S')
+              && (query[i + 8] == 'e' || query[i + 8] == 'E')
+              && (query[i + 9] == 'r' || query[i + 9] == 'R')
+              && (query[i + 10] == 't' || query[i + 10] == 'T')
+              && query[i + 11] == '_'
+              && (query[i + 12] == 'i' || query[i + 12] == 'I')
+              && (query[i + 13] == 'd' || query[i + 13] == 'D')
+              && query[i + 14] == '(') {
+            sb.append(car);
+            reWritablePrepare = false;
+            skipChar = true;
+          }
+          break;
+        case '(':
+          if (state == LexState.Normal) {
+            isInParenthesis++;
+          }
+          break;
+        case ')':
+          if (state == LexState.Normal) {
+            isInParenthesis--;
+            if (isInParenthesis == 0 && preValuePart2 != null && postValuePart == null) {
+              sb.append(car);
+              postValuePart = sb.toString();
+              sb.setLength(0);
+              skipChar = true;
+            }
+          }
+          break;
+        default:
+          if (state == LexState.Normal && isFirstChar && ((byte) car >= 40)) {
+            if (car == 'I' || car == 'i') {
+              isInsert = true;
+            } else if (car == 'R' || car == 'r') {
+              isReplace = true;
+            }
+            isFirstChar = false;
+          }
+          // multiple queries
+          if (state == LexState.Normal && semicolon && ((byte) car >= 40)) {
+            reWritablePrepare = false;
+          }
+          break;
+      }
+
+      lastChar = car;
+      if (skipChar) {
+        skipChar = false;
+      } else {
+        sb.append(car);
+      }
+    }
+
+    if (!hasParam) {
+      // permit to have rewrite without parameter
+      if (preValuePart1 == null) {
+        partList.add(0, sb.toString().getBytes(StandardCharsets.UTF_8));
+        partList.add(1, new byte[0]);
+      } else {
+        partList.add(0, preValuePart1.getBytes(StandardCharsets.UTF_8));
+        partList.add(1, sb.toString().getBytes(StandardCharsets.UTF_8));
+      }
+      sb.setLength(0);
+    } else {
+      partList.add(
+          0,
+          (preValuePart1 == null) ? new byte[0] : preValuePart1.getBytes(StandardCharsets.UTF_8));
+      partList.add(
+          1,
+          (preValuePart2 == null) ? new byte[0] : preValuePart2.getBytes(StandardCharsets.UTF_8));
+    }
+
+    if (!isInsert && !isReplace) {
+      reWritablePrepare = false;
+    }
+
+    // postValuePart is the value after the last parameter and parenthesis
+    // if no param, don't add to the list.
+    if (hasParam) {
+      partList.add(
+          (postValuePart == null) ? new byte[0] : postValuePart.getBytes(StandardCharsets.UTF_8));
+    }
+    partList.add(sb.toString().getBytes(StandardCharsets.UTF_8));
+
+    int staticLength = 1;
+    for (byte[] queryPart : partList) {
+      staticLength += queryPart.length;
+    }
+    return new RewriteClientParser(queryString, partList, staticLength, reWritablePrepare);
+  }
+
+  @Override
+  public String getSql() {
+    return sql;
+  }
+
+  @Override
+  public int getParamCount() {
+    return paramCount;
+  }
+
+  public List<byte[]> getQueryParts() {
+    return queryParts;
+  }
+
+  public boolean isQueryMultiValuesRewritable() {
+    return isQueryMultiValuesRewritable;
+  }
+
+  public int getQueryPartsLength() {
+    return queryPartsLength;
+  }
+}

--- a/src/test/java/com/singlestore/jdbc/integration/StatementTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/StatementTest.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTimeoutException;
+import java.sql.SQLTransientException;
 import java.sql.SQLWarning;
 import java.sql.Types;
 import java.util.concurrent.ExecutorService;
@@ -570,15 +571,15 @@ public class StatementTest extends Common {
     assertEquals(2, stmt.getQueryTimeout());
     stmt.execute("SELECT SLEEP(1)");
 
-    SQLNonTransientConnectionException exception =
+    SQLTransientException exception =
         assertThrows(
-            SQLNonTransientConnectionException.class,
+            SQLTimeoutException.class,
             () -> {
               stmt.setQueryTimeout(1);
               assertEquals(1, stmt.getQueryTimeout());
               stmt.execute("SELECT SLEEP(2)");
             });
-    assertTrue(exception.getMessage().endsWith("query timed out"));
+    assertTrue(exception.getMessage().endsWith("Query execution was interrupted"));
   }
 
   public void executeTimeOutQeuryWithPrepareStatement(PreparedStatement stmt) throws SQLException {
@@ -586,16 +587,16 @@ public class StatementTest extends Common {
     assertEquals(3, stmt.getQueryTimeout());
     stmt.executeQuery();
 
-    SQLNonTransientConnectionException exception =
+    SQLTransientException exception =
         assertThrows(
-            SQLNonTransientConnectionException.class,
+            SQLTimeoutException.class,
             () -> {
               stmt.setQueryTimeout(1);
               assertEquals(1, stmt.getQueryTimeout());
               stmt.executeQuery();
             });
 
-    assertTrue(exception.getMessage().endsWith("query timed out"));
+    assertTrue(exception.getMessage().endsWith("Query execution was interrupted"));
   }
 
   @Test


### PR DESCRIPTION
- Allow rewrite batch command for 'REPLACE' and 'ON DUPLICATE KEY'
- Fix rewrite batch command for not parameterized queries or partially parameterized
- In case if rewriteBatchedStatements is not possible try to execute in multi queries command
- Add more accurate packet size calculation to split by maxAllowedPacket