### PR TITLE
PLAT-5859: Add more types for convert function in native sql.

### DIFF
--- a/src/main/java/com/singlestore/jdbc/util/NativeSql.java
+++ b/src/main/java/com/singlestore/jdbc/util/NativeSql.java
@@ -262,17 +262,13 @@ public final class NativeSql {
 
         switch (typeParam) {
           case "BOOLEAN":
-            return "1=" + value;
-
+          case "DOUBLE":
+          case "FLOAT":
           case "BIGINT":
           case "SMALLINT":
-          case "TINYINT":
-            typeParam = "SIGNED INTEGER";
-            break;
-
           case "BIT":
-            typeParam = "UNSIGNED INTEGER";
-            break;
+          case "TINYINT":
+            return String.format("%s :> %s", value, typeParam);
 
           case "BLOB":
           case "VARBINARY":
@@ -293,12 +289,6 @@ public final class NativeSql {
           case "LONGNCHAR":
             typeParam = "CHAR";
             break;
-
-          case "DOUBLE":
-          case "FLOAT":
-            // SingleStore does not support converting to DOUBLE or FLOAT
-            // TODO: PLAT-5859
-            return "0.0+" + value;
 
           case "REAL":
           case "NUMERIC":

--- a/src/test/java/com/singlestore/jdbc/integration/ConnectionTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/ConnectionTest.java
@@ -260,16 +260,14 @@ public class ConnectionTest extends Common {
 
   @Test
   public void nativeSqlTest() throws SQLException {
-    // TODO: PLAT-5859
-    // Extend with additional test cases if :> is implemented
     String exp =
-        "SELECT convert(foo(a,b,c), SIGNED INTEGER)"
-            + ", convert(convert(?, CHAR), SIGNED INTEGER)"
-            + ", 1=?"
-            + ", 1=?"
-            + ", convert(?,   SIGNED INTEGER   )"
-            + ",  convert (?,   SIGNED INTEGER   )"
-            + ", convert(?, UNSIGNED INTEGER)"
+        "SELECT foo(a,b,c) :> BIGINT"
+            + ", convert(?, CHAR) :> BIGINT"
+            + ", ? :> BOOLEAN"
+            + ", ? :> BOOLEAN"
+            + ", ? :> SMALLINT"
+            + ", ? :> TINYINT"
+            + ", ? :> BIT"
             + ", convert(?, BINARY)"
             + ", convert(?, BINARY)"
             + ", convert(?, BINARY)"
@@ -286,8 +284,8 @@ public class ConnectionTest extends Common {
             + ", convert(?, CHAR)"
             + ", convert(?, CHAR)"
             + ", convert(?, CHAR)"
-            + ", 0.0+?"
-            + ", 0.0+?"
+            + ", ? :> FLOAT"
+            + ", ? :> DOUBLE"
             + ", convert(?, DECIMAL)"
             + ", convert(?, DECIMAL)"
             + ", convert(?, DECIMAL)"


### PR DESCRIPTION
Improve prepared statement sql query parsing:
* Replace 'convert' function with ':>' for types that are not supported in convert function. 