### PR TITLE
Get database product version when defaultFetchSize set

### DIFF
--- a/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
+++ b/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
@@ -7,6 +7,7 @@ package com.singlestore.jdbc;
 
 import com.singlestore.jdbc.client.DataType;
 import com.singlestore.jdbc.client.result.CompleteResult;
+import com.singlestore.jdbc.client.result.StreamingResult;
 import com.singlestore.jdbc.util.Version;
 import com.singlestore.jdbc.util.VersionFactory;
 import java.sql.PseudoColumnUsage;
@@ -171,9 +172,13 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
   private ResultSet executeQuery(String sql) throws SQLException {
     Statement stmt =
         connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-    CompleteResult rs = (CompleteResult) stmt.executeQuery(sql);
-    rs.setStatement(null); // bypass Hibernate statement tracking (CONJ-49)
-    rs.useAliasAsName();
+    ResultSet rs = stmt.executeQuery(sql);
+    if (rs instanceof CompleteResult) {
+      ((CompleteResult) rs).setStatement(null); // bypass Hibernate statement tracking (CONJ-49)
+      ((CompleteResult) rs).useAliasAsName();
+    } else if (rs instanceof StreamingResult) {
+      ((StreamingResult) rs).setStatement(null); // bypass Hibernate statement tracking (CONJ-49)
+    }
     return rs;
   }
 

--- a/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
+++ b/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
@@ -7,7 +7,6 @@ package com.singlestore.jdbc;
 
 import com.singlestore.jdbc.client.DataType;
 import com.singlestore.jdbc.client.result.CompleteResult;
-import com.singlestore.jdbc.client.result.StreamingResult;
 import com.singlestore.jdbc.util.Version;
 import com.singlestore.jdbc.util.VersionFactory;
 import java.sql.PseudoColumnUsage;
@@ -172,13 +171,10 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
   private ResultSet executeQuery(String sql) throws SQLException {
     Statement stmt =
         connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-    ResultSet rs = stmt.executeQuery(sql);
-    if (rs instanceof CompleteResult) {
-      ((CompleteResult) rs).setStatement(null); // bypass Hibernate statement tracking (CONJ-49)
-      ((CompleteResult) rs).useAliasAsName();
-    } else if (rs instanceof StreamingResult) {
-      ((StreamingResult) rs).setStatement(null); // bypass Hibernate statement tracking (CONJ-49)
-    }
+    stmt.setFetchSize(0);
+    CompleteResult rs = (CompleteResult) stmt.executeQuery(sql);
+    rs.setStatement(null); // bypass Hibernate statement tracking (CONJ-49)
+    rs.useAliasAsName();
     return rs;
   }
 

--- a/src/test/java/com/singlestore/jdbc/integration/DatabaseMetadataTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/DatabaseMetadataTest.java
@@ -1835,4 +1835,14 @@ public class DatabaseMetadataTest extends Common {
     assertEquals("java.lang.String", meta.getColumnClassName(1));
     assertEquals(Types.LONGVARCHAR, meta.getColumnType(1));
   }
+
+  @Test
+  public void getDatabaseVersionsWithDefaultFetchSize() throws SQLException {
+    try (com.singlestore.jdbc.Connection con = createCon("&defaultFetchSize=10")) {
+      // Should not give ClassCastException
+      con.getMetaData().getDatabaseProductVersion();
+      con.getMetaData().getDatabaseMajorVersion();
+      con.getMetaData().getDatabaseMinorVersion();
+    }
+  }
 }


### PR DESCRIPTION
I got a `ClassCastException` when calling `getDatabaseProductVersion()` on a connection that has `defaultFetchSize` set.

I made a small program to reproduce it.
```
import java.sql.*;
import java.util.Properties;

public class DbTest {
    public static void main(String[] args) throws SQLException {
        Properties properties = new Properties();
        properties.put("user", "root");
        properties.put("password", "*****");
        properties.put("defaultFetchSize", "5000");

        Connection connection = DriverManager.getConnection("jdbc:singlestore://localhost:3306", properties);
        String databaseProductVersion = connection.getMetaData().getDatabaseProductVersion();
        System.out.println("databaseProductVersion = " + databaseProductVersion);
    }
}
```
```
Exception in thread "main" java.lang.ClassCastException: class com.singlestore.jdbc.client.result.StreamingResult cannot be cast to class com.singlestore.jdbc.client.result.CompleteResult (com.singlestore.jdbc.client.result.StreamingResult and com.singlestore.jdbc.client.result.CompleteResult are in unnamed module of loader 'app')
	at com.singlestore.jdbc.DatabaseMetaData.executeQuery(DatabaseMetaData.java:175)
	at com.singlestore.jdbc.DatabaseMetaData.getSingleStoreVersion(DatabaseMetaData.java:148)
	at com.singlestore.jdbc.DatabaseMetaData.getDatabaseProductVersion(DatabaseMetaData.java:1058)
	at DbTest.main(DbTest.java:12)
```

`executeQuery` assumes it will get a `CompleteResult` but when `defaultFetchSize` is set it will get a `StreamingResult`.
My attempt at a fix does `instanceof` before casting. 