### PR TITLE
Tested driver with 8.7 SingleStore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,8 @@ workflows:
               singlestore_image:
                 - singlestore/cluster-in-a-box:alma-8.0.19-f48780d261-4.0.11-1.16.0
                 - singlestore/cluster-in-a-box:alma-8.1.32-e3d3cde6da-4.0.16-1.17.6
-                - singlestore/cluster-in-a-box:alma-8.5.7-bf633c1a54-4.0.17-1.17.8
+                - singlestore/cluster-in-a-box:alma-8.5.22-fe61f40cd1-4.1.0-1.17.11
+                - singlestore/cluster-in-a-box:alma-8.7.12-483e5f8acb-4.1.0-1.17.15
   publish:
     jobs:
       - test_jdk:

--- a/src/main/java/com/singlestore/jdbc/client/ColumnDecoder.java
+++ b/src/main/java/com/singlestore/jdbc/client/ColumnDecoder.java
@@ -36,7 +36,7 @@ public interface ColumnDecoder extends Column {
 
     buf.skip(); // skip length always 0x0c
     short charset = buf.readShort();
-    int length = buf.readInt();
+    long length = Integer.toUnsignedLong(buf.readInt());
     DataType dataType = DataType.of(buf.readUnsignedByte());
     int flags = buf.readUnsignedShort();
     byte decimals = buf.readByte();

--- a/src/main/java/com/singlestore/jdbc/message/server/ColumnDefinitionPacket.java
+++ b/src/main/java/com/singlestore/jdbc/message/server/ColumnDefinitionPacket.java
@@ -161,7 +161,7 @@ public class ColumnDefinitionPacket implements Column, ServerMessage {
           return Integer.MAX_VALUE;
         }
         return (int)
-            Long.max(Long.divideUnsigned(columnLength, maxWidth.longValue()), Integer.MAX_VALUE);
+            Long.min(Long.divideUnsigned(columnLength, maxWidth.longValue()), Integer.MAX_VALUE);
 
       case DATE:
         return 10;

--- a/src/test/java/com/singlestore/jdbc/integration/DatabaseMetadataTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/DatabaseMetadataTest.java
@@ -503,7 +503,11 @@ public class DatabaseMetadataTest extends Common {
     assertEquals("", rs.getString(12)); // REMARKS
 
     assertTrue("null".equalsIgnoreCase(rs.getString(13)) || rs.getString(13) == null); // COLUMN_DEF
-    assertEquals(32 * 3, rs.getInt(16)); // CHAR_OCTET_LENGTH
+    if (minVersion(8, 7, 0)) {
+      assertEquals(32 * 4, rs.getInt(16)); // CHAR_OCTET_LENGTH
+    } else {
+      assertEquals(32 * 3, rs.getInt(16)); // CHAR_OCTET_LENGTH
+    }
     assertEquals(2, rs.getInt(17)); // ORDINAL_POSITION
     assertEquals("YES", rs.getString(18)); // IS_NULLABLE
     assertEquals(null, rs.getString(19)); // SCOPE_CATALOG

--- a/src/test/java/com/singlestore/jdbc/integration/resultset/ResultSetMetadataTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/resultset/ResultSetMetadataTest.java
@@ -202,7 +202,7 @@ public class ResultSetMetadataTest extends Common {
     assertEquals(8, rsmd.getPrecision(2));
     assertEquals(9, rsmd.getPrecision(3));
     assertEquals(10, rsmd.getPrecision(4));
-    assertEquals(1431655765, rsmd.getPrecision(5));
+    assertEquals(1073741823, rsmd.getPrecision(5));
     assertEquals(2147483647, rsmd.getPrecision(12));
     assertEquals(0, rsmd.getPrecision(13));
   }

--- a/src/test/java/com/singlestore/jdbc/integration/resultset/ResultSetMetadataTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/resultset/ResultSetMetadataTest.java
@@ -202,7 +202,11 @@ public class ResultSetMetadataTest extends Common {
     assertEquals(8, rsmd.getPrecision(2));
     assertEquals(9, rsmd.getPrecision(3));
     assertEquals(10, rsmd.getPrecision(4));
-    assertEquals(1073741823, rsmd.getPrecision(5));
+    if (minVersion(8, 7, 0)) {
+      assertEquals(1073741823, rsmd.getPrecision(5));
+    } else {
+      assertEquals(1431655765, rsmd.getPrecision(5));
+    }
     assertEquals(2147483647, rsmd.getPrecision(12));
     assertEquals(0, rsmd.getPrecision(13));
   }


### PR DESCRIPTION
 - In 8.7 we are using 4 byte charset by default
 - Fixed a bug when max length (4GB) was read into an int (as a result, we got -1)
 - Fixed a bug where instead of taking minimum length and MAXINT we took maximum