### PR TITLE
PLAT-7202: Fix read BIT type values as byte array

### DIFF
--- a/src/main/java/com/singlestore/jdbc/client/ReadableByteBuf.java
+++ b/src/main/java/com/singlestore/jdbc/client/ReadableByteBuf.java
@@ -69,6 +69,14 @@ public interface ReadableByteBuf {
   SingleStoreBlob readBlob(int length);
 
   /**
+   * Read Blob from BIT type skipping leading zero bytes in array.
+   *
+   * @param length original byte array length
+   * @return Blob
+   */
+  SingleStoreBlob readBlobFromBit(int length);
+
+  /**
    * Read byte from buffer at current position, without changing position
    *
    * @return byte value

--- a/src/main/java/com/singlestore/jdbc/client/ReadableByteBuf.java
+++ b/src/main/java/com/singlestore/jdbc/client/ReadableByteBuf.java
@@ -69,14 +69,6 @@ public interface ReadableByteBuf {
   SingleStoreBlob readBlob(int length);
 
   /**
-   * Read Blob from BIT type skipping leading zero bytes in array.
-   *
-   * @param length original byte array length
-   * @return Blob
-   */
-  SingleStoreBlob readBlobFromBit(int length);
-
-  /**
    * Read byte from buffer at current position, without changing position
    *
    * @return byte value

--- a/src/main/java/com/singlestore/jdbc/client/column/BitColumn.java
+++ b/src/main/java/com/singlestore/jdbc/client/column/BitColumn.java
@@ -11,7 +11,6 @@ import com.singlestore.jdbc.client.DataType;
 import com.singlestore.jdbc.client.ReadableByteBuf;
 import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.message.server.ColumnDefinitionPacket;
-import com.singlestore.jdbc.plugin.codec.ByteArrayCodec;
 import com.singlestore.jdbc.plugin.codec.ByteCodec;
 import java.sql.Date;
 import java.sql.SQLDataException;
@@ -87,7 +86,9 @@ public class BitColumn extends ColumnDefinitionPacket implements ColumnDecoder {
   @Override
   public Object getDefaultText(final Configuration conf, ReadableByteBuf buf, MutableInt length)
       throws SQLDataException {
-    return ByteArrayCodec.parseBit(buf, length);
+    byte[] arr = new byte[length.get()];
+    buf.readBytes(arr);
+    return arr;
   }
 
   @Override
@@ -109,7 +110,13 @@ public class BitColumn extends ColumnDefinitionPacket implements ColumnDecoder {
 
   @Override
   public byte decodeByteText(ReadableByteBuf buf, MutableInt length) throws SQLDataException {
-    return ByteArrayCodec.parseBit(buf, length)[0];
+    int index = 0;
+    byte val = 0;
+    while (index++ < length.get() && val == 0) {
+      val = buf.readByte();
+    }
+    buf.skip(length.get() - index + 1);
+    return val;
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/client/column/BitColumn.java
+++ b/src/main/java/com/singlestore/jdbc/client/column/BitColumn.java
@@ -11,7 +11,7 @@ import com.singlestore.jdbc.client.DataType;
 import com.singlestore.jdbc.client.ReadableByteBuf;
 import com.singlestore.jdbc.client.util.MutableInt;
 import com.singlestore.jdbc.message.server.ColumnDefinitionPacket;
-import com.singlestore.jdbc.plugin.codec.BitSetCodec;
+import com.singlestore.jdbc.plugin.codec.ByteArrayCodec;
 import com.singlestore.jdbc.plugin.codec.ByteCodec;
 import java.sql.Date;
 import java.sql.SQLDataException;
@@ -87,7 +87,7 @@ public class BitColumn extends ColumnDefinitionPacket implements ColumnDecoder {
   @Override
   public Object getDefaultText(final Configuration conf, ReadableByteBuf buf, MutableInt length)
       throws SQLDataException {
-    return BitSetCodec.parseBit(buf, length);
+    return ByteArrayCodec.parseBit(buf, length);
   }
 
   @Override
@@ -109,9 +109,7 @@ public class BitColumn extends ColumnDefinitionPacket implements ColumnDecoder {
 
   @Override
   public byte decodeByteText(ReadableByteBuf buf, MutableInt length) throws SQLDataException {
-    byte val = buf.readByte();
-    if (length.get() > 1) buf.skip(length.get() - 1);
-    return val;
+    return ByteArrayCodec.parseBit(buf, length)[0];
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/client/impl/StandardReadableByteBuf.java
+++ b/src/main/java/com/singlestore/jdbc/client/impl/StandardReadableByteBuf.java
@@ -88,9 +88,20 @@ public final class StandardReadableByteBuf implements ReadableByteBuf {
     }
   }
 
+  @Override
   public SingleStoreBlob readBlob(int length) {
     pos += length;
     return SingleStoreBlob.safeSingleStoreBlob(buf, pos - length, length);
+  }
+
+  @Override
+  public SingleStoreBlob readBlobFromBit(int length) {
+    int index = pos;
+    while (index < pos + length - 1 && buf[index] == (byte) 0) {
+      index++; // non -zero index
+    }
+    pos += length;
+    return SingleStoreBlob.safeSingleStoreBlob(buf, index, pos - index);
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/client/impl/StandardReadableByteBuf.java
+++ b/src/main/java/com/singlestore/jdbc/client/impl/StandardReadableByteBuf.java
@@ -95,16 +95,6 @@ public final class StandardReadableByteBuf implements ReadableByteBuf {
   }
 
   @Override
-  public SingleStoreBlob readBlobFromBit(int length) {
-    int index = pos;
-    while (index < pos + length - 1 && buf[index] == (byte) 0) {
-      index++; // non -zero index
-    }
-    pos += length;
-    return SingleStoreBlob.safeSingleStoreBlob(buf, index, pos - index);
-  }
-
-  @Override
   public long atoll(int length) {
     boolean negate = false;
     int idx = 0;

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BigDecimalCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BigDecimalCodec.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (c) 2012-2014 Monty Program Ab
-// Copyright (c) 2015-2023 MariaDB Corporation Ab
-// Copyright (c) 2021-2023 SingleStore, Inc.
+// Copyright (c) 2015-2024 MariaDB Corporation Ab
+// Copyright (c) 2021-2024 SingleStore, Inc.
 
 package com.singlestore.jdbc.plugin.codec;
 
@@ -32,7 +32,6 @@ public class BigDecimalCodec implements Codec<BigDecimal> {
           DataType.DOUBLE,
           DataType.BIGINT,
           DataType.BIT,
-          DataType.DECIMAL,
           DataType.OLDDECIMAL,
           DataType.YEAR,
           DataType.DECIMAL,

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BigIntegerCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BigIntegerCodec.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (c) 2012-2014 Monty Program Ab
-// Copyright (c) 2015-2023 MariaDB Corporation Ab
-// Copyright (c) 2021-2023 SingleStore, Inc.
+// Copyright (c) 2015-2024 MariaDB Corporation Ab
+// Copyright (c) 2021-2024 SingleStore, Inc.
 
 package com.singlestore.jdbc.plugin.codec;
 
@@ -29,7 +29,6 @@ public class BigIntegerCodec implements Codec<BigInteger> {
           DataType.MEDIUMINT,
           DataType.INT,
           DataType.BIGINT,
-          DataType.DECIMAL,
           DataType.YEAR,
           DataType.DOUBLE,
           DataType.DECIMAL,

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BlobCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BlobCodec.java
@@ -5,7 +5,6 @@
 
 package com.singlestore.jdbc.plugin.codec;
 
-import com.singlestore.jdbc.SingleStoreBlob;
 import com.singlestore.jdbc.client.ColumnDecoder;
 import com.singlestore.jdbc.client.Context;
 import com.singlestore.jdbc.client.DataType;
@@ -61,13 +60,14 @@ public class BlobCodec implements Codec<Blob> {
     switch (column.getType()) {
       case CHAR:
       case VARCHAR:
-      case BIT:
       case TINYBLOB:
       case MEDIUMBLOB:
       case LONGBLOB:
       case BLOB:
       case GEOMETRY:
         return buf.readBlob(length.get());
+      case BIT:
+        return buf.readBlobFromBit(length.get());
 
       default:
         buf.skip(length.get());
@@ -84,14 +84,14 @@ public class BlobCodec implements Codec<Blob> {
     switch (column.getType()) {
       case CHAR:
       case VARCHAR:
-      case BIT:
       case TINYBLOB:
       case MEDIUMBLOB:
       case LONGBLOB:
       case BLOB:
       case GEOMETRY:
-        buf.skip(length.get());
-        return new SingleStoreBlob(buf.buf(), buf.pos() - length.get(), length.get());
+        return buf.readBlob(length.get());
+      case BIT:
+        return buf.readBlobFromBit(length.get());
 
       default:
         buf.skip(length.get());

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/BlobCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/BlobCodec.java
@@ -63,11 +63,10 @@ public class BlobCodec implements Codec<Blob> {
       case TINYBLOB:
       case MEDIUMBLOB:
       case LONGBLOB:
+      case BIT:
       case BLOB:
       case GEOMETRY:
         return buf.readBlob(length.get());
-      case BIT:
-        return buf.readBlobFromBit(length.get());
 
       default:
         buf.skip(length.get());
@@ -88,10 +87,9 @@ public class BlobCodec implements Codec<Blob> {
       case MEDIUMBLOB:
       case LONGBLOB:
       case BLOB:
+      case BIT:
       case GEOMETRY:
         return buf.readBlob(length.get());
-      case BIT:
-        return buf.readBlobFromBit(length.get());
 
       default:
         buf.skip(length.get());

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/ByteArrayCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/ByteArrayCodec.java
@@ -15,7 +15,6 @@ import com.singlestore.jdbc.plugin.Codec;
 import java.io.IOException;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.EnumSet;
 
@@ -71,39 +70,16 @@ public class ByteArrayCodec implements Codec<byte[]> {
       case LONGBLOB:
       case CHAR:
       case VARCHAR:
+      case BIT:
       case GEOMETRY:
         byte[] arr = new byte[length.get()];
         buf.readBytes(arr);
         return arr;
-      case BIT:
-        return parseBit(buf, length);
       default:
         buf.skip(length.get());
         throw new SQLDataException(
             String.format("Data type %s cannot be decoded as byte[]", column.getType()));
     }
-  }
-
-  /**
-   * Reads BIT type as 8 bytes array and removes the leading zero bytes. SingleStore returns 8 bytes
-   * array with leading zero bytes for BIT type.
-   *
-   * @param buf to read
-   * @param length length of data
-   * @return byte array of BIT column
-   */
-  public static byte[] parseBit(ReadableByteBuf buf, MutableInt length) {
-    byte[] arr = new byte[length.get()];
-    buf.readBytes(arr);
-    // removes the leading zero bytes from array
-    int index = 0;
-    while (index < arr.length && arr[index] == (byte) 0) {
-      index++;
-    }
-    if (arr.length == index) {
-      return new byte[] {0};
-    }
-    return Arrays.copyOfRange(arr, index, arr.length);
   }
 
   @Override

--- a/src/main/java/com/singlestore/jdbc/plugin/codec/StreamCodec.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/codec/StreamCodec.java
@@ -27,10 +27,6 @@ public class StreamCodec implements Codec<InputStream> {
 
   private static final EnumSet<DataType> COMPATIBLE_TYPES =
       EnumSet.of(
-          DataType.BLOB,
-          DataType.TINYBLOB,
-          DataType.MEDIUMBLOB,
-          DataType.LONGBLOB,
           DataType.VARCHAR,
           DataType.CHAR,
           DataType.BLOB,

--- a/src/test/java/com/singlestore/jdbc/integration/codec/BitCodecTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/codec/BitCodecTest.java
@@ -76,13 +76,23 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getObject(ResultSet rs) throws SQLException {
-    assertArrayEquals(new byte[] {(byte) 0}, (byte[]) rs.getObject(1));
+    assertArrayEquals(
+        new byte[] {(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0},
+        (byte[]) rs.getObject(1));
     assertFalse(rs.wasNull());
-    assertArrayEquals(new byte[] {(byte) 1}, (byte[]) rs.getObject(2));
+    assertArrayEquals(
+        new byte[] {(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 1},
+        (byte[]) rs.getObject(2));
     assertEquals((byte) 1, (byte) rs.getObject(2, Byte.class));
-    assertArrayEquals(new byte[] {(byte) 1}, (byte[]) rs.getObject("t2alias"));
+    assertArrayEquals(
+        new byte[] {(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 1},
+        (byte[]) rs.getObject("t2alias"));
     assertFalse(rs.wasNull());
-    assertArrayEquals(new byte[] {(byte) 15, (byte) 4}, (byte[]) rs.getObject(3));
+    assertArrayEquals(
+        new byte[] {
+          (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 15, (byte) 4
+        },
+        (byte[]) rs.getObject(3));
     assertEquals((byte) 15, (byte) rs.getObject(3, Byte.class));
     assertFalse(rs.wasNull());
     assertNull(rs.getObject(4));
@@ -114,7 +124,7 @@ public class BitCodecTest extends CommonCodecTest {
     testErrObject(rs, Double.class);
     testErrObject(rs, Float.class);
     testObject(rs, Byte.class, (byte) 0);
-    testObject(rs, byte[].class, new byte[] {0});
+    testObject(rs, byte[].class, new byte[] {0, 0, 0, 0, 0, 0, 0, 0});
     testErrObject(rs, Date.class);
     testErrObject(rs, Time.class);
     testErrObject(rs, Timestamp.class);
@@ -513,11 +523,11 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getBytes(ResultSet rs) throws SQLException {
-    assertArrayEquals(new byte[] {0}, rs.getBytes(1));
+    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 0, 0}, rs.getBytes(1));
     assertFalse(rs.wasNull());
-    assertArrayEquals(new byte[] {1}, rs.getBytes(2));
+    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 0, 1}, rs.getBytes(2));
     assertFalse(rs.wasNull());
-    assertArrayEquals(new byte[] {15, 4}, rs.getBytes(3));
+    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 15, 4}, rs.getBytes(3));
     assertFalse(rs.wasNull());
     assertNull(rs.getBytes(4));
     assertTrue(rs.wasNull());
@@ -579,12 +589,60 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getBlob(ResultSet rs) throws SQLException {
-    assertEquals(new SingleStoreBlob(new byte[] {(byte) 0x00}), rs.getBlob(1));
+    assertEquals(
+        new SingleStoreBlob(
+            new byte[] {
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00
+            }),
+        rs.getBlob(1));
     assertFalse(rs.wasNull());
-    assertEquals(new SingleStoreBlob(new byte[] {(byte) 0x01}), rs.getBlob(2));
-    assertEquals(new SingleStoreBlob(new byte[] {0x01}), rs.getBlob("t2alias"));
+    assertEquals(
+        new SingleStoreBlob(
+            new byte[] {
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x01
+            }),
+        rs.getBlob(2));
+    assertEquals(
+        new SingleStoreBlob(
+            new byte[] {
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x01
+            }),
+        rs.getBlob("t2alias"));
     assertFalse(rs.wasNull());
-    assertEquals(new SingleStoreBlob(new byte[] {(byte) 15, (byte) 4}), rs.getBlob(3));
+    assertEquals(
+        new SingleStoreBlob(
+            new byte[] {
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 0x00,
+              (byte) 15,
+              (byte) 4
+            }),
+        rs.getBlob(3));
     assertFalse(rs.wasNull());
     assertNull(rs.getBlob(4));
     assertTrue(rs.wasNull());

--- a/src/test/java/com/singlestore/jdbc/integration/codec/BitCodecTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/codec/BitCodecTest.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (c) 2012-2014 Monty Program Ab
-// Copyright (c) 2015-2021 MariaDB Corporation Ab
-// Copyright (c) 2021 SingleStore, Inc.
+// Copyright (c) 2015-2024 MariaDB Corporation Ab
+// Copyright (c) 2021-2024 SingleStore, Inc.
 
 package com.singlestore.jdbc.integration.codec;
 
@@ -38,17 +38,14 @@ public class BitCodecTest extends CommonCodecTest {
     stmt.execute(
         createRowstore()
             + " TABLE BitCodec2 (id int not null primary key auto_increment, t1 BIT(16))");
-    stmt.execute("FLUSH TABLES");
   }
 
   private ResultSet get() throws SQLException {
     Statement stmt = sharedConn.createStatement();
-    stmt.execute("START TRANSACTION"); // if MAXSCALE ensure using WRITER
     ResultSet rs =
         stmt.executeQuery(
             "select t1 as t1alias, t2 as t2alias, t3 as t3alias, t4 as t4alias from BitCodec ORDER BY id");
     assertTrue(rs.next());
-    sharedConn.commit();
     return rs;
   }
 
@@ -79,12 +76,14 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getObject(ResultSet rs) throws SQLException {
-    assertEquals(BitSet.valueOf(new byte[] {(byte) 0}), rs.getObject(1));
+    assertArrayEquals(new byte[] {(byte) 0}, (byte[]) rs.getObject(1));
     assertFalse(rs.wasNull());
-    assertEquals(BitSet.valueOf(new byte[] {(byte) 1}), rs.getObject(2));
-    assertEquals(BitSet.valueOf(new byte[] {(byte) 1}), rs.getObject("t2alias"));
+    assertArrayEquals(new byte[] {(byte) 1}, (byte[]) rs.getObject(2));
+    assertEquals((byte) 1, (byte) rs.getObject(2, Byte.class));
+    assertArrayEquals(new byte[] {(byte) 1}, (byte[]) rs.getObject("t2alias"));
     assertFalse(rs.wasNull());
-    assertEquals(BitSet.valueOf(new byte[] {(byte) 4, (byte) 15}), rs.getObject(3));
+    assertArrayEquals(new byte[] {(byte) 15, (byte) 4}, (byte[]) rs.getObject(3));
+    assertEquals((byte) 15, (byte) rs.getObject(3, Byte.class));
     assertFalse(rs.wasNull());
     assertNull(rs.getObject(4));
     assertTrue(rs.wasNull());
@@ -102,11 +101,11 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getObjectType(ResultSet rs) throws Exception {
-    testObject(rs, Integer.class, Integer.valueOf(0));
+    testObject(rs, Integer.class, 0);
     testObject(rs, Byte.class, Byte.valueOf("0"));
     testObject(rs, String.class, "b''");
-    testObject(rs, Long.class, Long.valueOf(0));
-    testObject(rs, Short.class, Short.valueOf((short) 0));
+    testObject(rs, Long.class, 0L);
+    testObject(rs, Short.class, (short) 0);
     testObject(rs, BitSet.class, BitSet.valueOf(new byte[] {(byte) 0}));
     testObject(rs, BigDecimal.class, BigDecimal.valueOf(0));
     testObject(rs, BigInteger.class, BigInteger.valueOf(0));
@@ -115,7 +114,7 @@ public class BitCodecTest extends CommonCodecTest {
     testErrObject(rs, Double.class);
     testErrObject(rs, Float.class);
     testObject(rs, Byte.class, (byte) 0);
-    testArrObject(rs, byte[].class, new byte[] {0, 0, 0, 0, 0, 0, 0, 0});
+    testObject(rs, byte[].class, new byte[] {0});
     testErrObject(rs, Date.class);
     testErrObject(rs, Time.class);
     testErrObject(rs, Timestamp.class);
@@ -214,10 +213,10 @@ public class BitCodecTest extends CommonCodecTest {
   public void getByte(ResultSet rs) throws SQLException {
     assertEquals((byte) 0, rs.getByte(1));
     assertFalse(rs.wasNull());
-    assertEquals((byte) 0, rs.getByte(2));
-    assertEquals((byte) 0, rs.getByte("t2alias"));
+    assertEquals((byte) 1, rs.getByte(2));
+    assertEquals((byte) 1, rs.getByte("t2alias"));
     assertFalse(rs.wasNull());
-    assertEquals((byte) 0, rs.getByte(3));
+    assertEquals((byte) 15, rs.getByte(3));
     assertFalse(rs.wasNull());
     assertEquals((byte) 0, rs.getByte(4));
     assertTrue(rs.wasNull());
@@ -514,11 +513,11 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getBytes(ResultSet rs) throws SQLException {
-    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 0, 0}, rs.getBytes(1));
+    assertArrayEquals(new byte[] {0}, rs.getBytes(1));
     assertFalse(rs.wasNull());
-    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 0, 1}, rs.getBytes(2));
+    assertArrayEquals(new byte[] {1}, rs.getBytes(2));
     assertFalse(rs.wasNull());
-    assertArrayEquals(new byte[] {0, 0, 0, 0, 0, 0, 15, 4}, rs.getBytes(3));
+    assertArrayEquals(new byte[] {15, 4}, rs.getBytes(3));
     assertFalse(rs.wasNull());
     assertNull(rs.getBytes(4));
     assertTrue(rs.wasNull());
@@ -580,19 +579,12 @@ public class BitCodecTest extends CommonCodecTest {
   }
 
   public void getBlob(ResultSet rs) throws SQLException {
-    assertEquals(
-        new SingleStoreBlob(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
-        rs.getBlob(1));
+    assertEquals(new SingleStoreBlob(new byte[] {(byte) 0x00}), rs.getBlob(1));
     assertFalse(rs.wasNull());
-    assertEquals(
-        new SingleStoreBlob(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}),
-        rs.getBlob(2));
-    assertEquals(
-        new SingleStoreBlob(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}),
-        rs.getBlob("t2alias"));
+    assertEquals(new SingleStoreBlob(new byte[] {(byte) 0x01}), rs.getBlob(2));
+    assertEquals(new SingleStoreBlob(new byte[] {0x01}), rs.getBlob("t2alias"));
     assertFalse(rs.wasNull());
-    assertEquals(
-        new SingleStoreBlob(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 15, 4}), rs.getBlob(3));
+    assertEquals(new SingleStoreBlob(new byte[] {(byte) 15, (byte) 4}), rs.getBlob(3));
     assertFalse(rs.wasNull());
     assertNull(rs.getBlob(4));
     assertTrue(rs.wasNull());

--- a/src/test/java/com/singlestore/jdbc/integration/codec/CommonCodecTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/codec/CommonCodecTest.java
@@ -61,8 +61,10 @@ public class CommonCodecTest extends Common {
       assertNull(rs.getObject("t4alias", objClass));
     } else if (exp instanceof InputStream) {
       assertStreamEquals((InputStream) exp, (InputStream) rs.getObject(idx, objClass));
-      //      assertStreamEquals((InputStream) exp, (InputStream) rs.getObject("t1alias",
-      // objClass));
+      assertNull(rs.getObject(4, objClass));
+      assertNull(rs.getObject("t4alias", objClass));
+    } else if (exp instanceof byte[]) {
+      assertArrayEquals((byte[]) exp, (byte[]) rs.getObject(idx, objClass));
       assertNull(rs.getObject(4, objClass));
       assertNull(rs.getObject("t4alias", objClass));
     } else if (exp instanceof Reader) {


### PR DESCRIPTION
* ResultSet.getObject was previously returning a BitSet with reversed bytes by default (a critical defect persisting from older versions).
**This has been changed to return a byte array.**
* ResultSet.getByte was returning incorrect values due to the presence of leading zeros.
**Return first not 0 byte or the latest one**