### PR TITLE
PLAT-7195: Fix column display size. Add charset metadata test.

### DIFF
--- a/src/main/java/com/singlestore/jdbc/message/server/ColumnDefinitionPacket.java
+++ b/src/main/java/com/singlestore/jdbc/message/server/ColumnDefinitionPacket.java
@@ -139,30 +139,15 @@ public class ColumnDefinitionPacket implements Column, ServerMessage {
   public int getDisplaySize() {
     switch (dataType) {
       case VARCHAR:
-      case JSON:
       case ENUM:
       case SET:
       case CHAR:
-      case MEDIUMBLOB:
-      case BLOB:
-      case TINYBLOB:
         Integer maxWidth = CharsetEncodingLength.maxCharlen.get(charset);
         if (maxWidth == null) {
-          return (int) columnLength;
-        }
-        return (int) columnLength / maxWidth;
-
-        // server sends MAX_UNSIGNEDINT or 4GB (or -1 if interpreted as int) as length for this.
-        // For LONGBLOB with maxWidth 1 this doesn't fit into an int, so return MAXINT.
-        // For LONGTEXT with maxWidth of at least 2, the precision fits
-      case LONGBLOB:
-        maxWidth = CharsetEncodingLength.maxCharlen.get(charset);
-        if (maxWidth == null) {
-          return Integer.MAX_VALUE;
+          return (int) Long.min(columnLength, Integer.MAX_VALUE);
         }
         return (int)
             Long.min(Long.divideUnsigned(columnLength, maxWidth.longValue()), Integer.MAX_VALUE);
-
       case DATE:
         return 10;
       case DATETIME:
@@ -180,7 +165,7 @@ public class ColumnDefinitionPacket implements Column, ServerMessage {
         return 18;
 
       default:
-        return (int) columnLength;
+        return (int) Long.min(columnLength, Integer.MAX_VALUE);
     }
   }
 

--- a/src/test/java/com/singlestore/jdbc/integration/codec/ClobCodecTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/codec/ClobCodecTest.java
@@ -762,9 +762,8 @@ public class ClobCodecTest extends CommonCodecTest {
     assertEquals(4, meta.getColumnCount());
     assertEquals(0, meta.getScale(1));
     assertEquals("", meta.getSchemaName(1));
-    int prec = minVersion(7, 8, 0) ? 63 : minVersion(7, 5, 0) ? 340 : 255;
-    assertEquals(prec, meta.getPrecision(1));
-    assertEquals(prec, meta.getColumnDisplaySize(1));
+    assertEquals(255, meta.getPrecision(1));
+    assertEquals(255, meta.getColumnDisplaySize(1));
   }
 
   @Test


### PR DESCRIPTION
Fix column display size for:
TINYTEXT/TINYBLOB = 255 bytes
MEDIUMTEXT/MEDIUMBLOB = 16Mb
BLOB/TEXT = 65,535 bytes

LONGTEXT/LONGBLOB/JSON return Integer.MAX_VALUE as unknown(they have limit of 4Gb but in practice are limited by max_allowed_packet ~ max 1Gb)

Notes:
BOOL, TINYINT always returns 4 bytes length
DOUBLE always returns 50 bytes length -> hardcoded to return 18 instead

