### PR TITLE
PLAT-7210: Fix Year type metadata

### DIFF
--- a/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
+++ b/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
@@ -61,11 +61,6 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
               + upperCaseWithoutSize
               + ")";
     }
-
-    if (!conf.yearIsDateType()) {
-      upperCaseWithoutSize =
-          " IF(c.COLUMN_TYPE IN ('year(2)', 'year(4)'), 'SMALLINT', " + upperCaseWithoutSize + ")";
-    }
     if (!isExtendedTypesEnabled()) {
       upperCaseWithoutSize =
           " IF(c.COLUMN_TYPE LIKE 'vector%', "
@@ -733,8 +728,8 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
             + " TYPE_NAME, "
             + " CASE c.DATA_TYPE"
             + DateTimeSizeClause(fullTypeColumnName)
-            + (conf.yearIsDateType() ? "" : " WHEN 'year' THEN 5")
-            + "  WHEN 'json' THEN "
+            + " WHEN 'year' THEN 4"
+            + " WHEN 'json' THEN "
             + Integer.MAX_VALUE
             + "  WHEN 'bson' THEN "
             + Integer.MAX_VALUE

--- a/src/test/java/com/singlestore/jdbc/integration/resultset/ResultSetMetadataTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/resultset/ResultSetMetadataTest.java
@@ -191,7 +191,7 @@ public class ResultSetMetadataTest extends Common {
       if (i == 32 || i == 33) {
         continue;
       }
-      if ("DOUBLE".equals(colName) || "YEAR".equals(colName)) { // PLAT-7210
+      if ("DOUBLE".equals(colName)) {
         continue;
       }
       assertEquals(rsmd.getPrecision(i), cols.getInt("COLUMN_SIZE"));


### PR DESCRIPTION
when yearIsDateType is true:
           
getColumnTypeName: YEAR         
getColumnType: 91                
getColumnClassName: java.sql.Date      
getColumnDisplaySize: 4                      
getPrecision: 4        

when yearIsDateType is false:

getColumnTypeName: YEAR         
getColumnType: 5                
getColumnClassName: java.lang.Short      
getColumnDisplaySize: 4                      
getPrecision: 4     