### PR TITLE
Plat 7329 DatabaseMetaData.getTypeInfo add missed types

### DIFF
--- a/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
+++ b/src/main/java/com/singlestore/jdbc/DatabaseMetaData.java
@@ -11,6 +11,10 @@ import com.singlestore.jdbc.util.Version;
 import com.singlestore.jdbc.util.VersionFactory;
 import java.sql.*;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 
 public class DatabaseMetaData implements java.sql.DatabaseMetaData {
 
@@ -2394,7 +2398,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
       DataType.INT
     };
 
-    String[][] data = {
+    String[][] baseData = {
       {"BIT", "-7", "1", "", "", "", "1", "1", "3", "0", "0", "0", "BIT", "0", "0", "0", "0", "10"},
       {
         "BOOL", "-7", "1", "", "", "", "1", "1", "3", "0", "0", "0", "BOOL", "0", "0", "0", "0",
@@ -2406,7 +2410,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "3",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)] [UNSIGNED]",
         "1",
         "0",
         "3",
@@ -2426,7 +2430,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "3",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)]",
         "1",
         "0",
         "3",
@@ -2446,7 +2450,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "19",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)] [UNSIGNED]",
         "1",
         "0",
         "3",
@@ -2466,7 +2470,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "20",
         "",
         "",
-        "[(M)] [ZEROFILL]",
+        "[(M)]",
         "1",
         "0",
         "3",
@@ -2677,12 +2681,32 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "0", "10"
       },
       {
+        "JSON",
+        "-1",
+        "2147483647",
+        "'",
+        "'",
+        "",
+        "1",
+        "1",
+        "3",
+        "0",
+        "0",
+        "0",
+        "JSON",
+        "0",
+        "0",
+        "0",
+        "0",
+        "10"
+      },
+      {
         "NUMERIC",
         "2",
         "65",
         "",
         "",
-        "[(M,D])] [ZEROFILL]",
+        "[(M,D])]",
         "1",
         "0",
         "3",
@@ -2702,7 +2726,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "65",
         "",
         "",
-        "[(M,D])] [ZEROFILL]",
+        "[(M,D])]",
         "1",
         "0",
         "3",
@@ -2722,7 +2746,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "10",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)] [UNSIGNED]",
         "1",
         "0",
         "3",
@@ -2742,7 +2766,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "10",
         "",
         "",
-        "[(M)] [ZEROFILL]",
+        "[(M)]",
         "1",
         "0",
         "3",
@@ -2762,7 +2786,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "10",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)] [UNSIGNED]",
         "1",
         "0",
         "3",
@@ -2782,7 +2806,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "10",
         "",
         "",
-        "[(M)] [ZEROFILL]",
+        "[(M)]",
         "1",
         "0",
         "3",
@@ -2802,7 +2826,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "7",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)] [UNSIGNED]",
         "1",
         "0",
         "3",
@@ -2822,7 +2846,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "8",
         "",
         "",
-        "[(M)] [ZEROFILL]",
+        "[(M)]",
         "1",
         "0",
         "3",
@@ -2842,7 +2866,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "5",
         "",
         "",
-        "[(M)] [UNSIGNED] [ZEROFILL]",
+        "[(M)] [UNSIGNED]",
         "1",
         "0",
         "3",
@@ -2862,7 +2886,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "5",
         "",
         "",
-        "[(M)] [ZEROFILL]",
+        "[(M)]",
         "1",
         "0",
         "3",
@@ -2877,44 +2901,12 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "10"
       },
       {
-        "FLOAT",
-        "7",
-        "10",
-        "",
-        "",
-        "[(M|D)] [ZEROFILL]",
-        "1",
-        "0",
-        "3",
-        "0",
-        "0",
-        "1",
-        "FLOAT",
-        "-38",
-        "38",
-        "0",
-        "0",
-        "10"
+        "FLOAT", "7", "10", "", "", "[(M|D)]", "1", "0", "3", "0", "0", "1", "FLOAT", "-38", "38",
+        "0", "0", "10"
       },
       {
-        "DOUBLE",
-        "8",
-        "17",
-        "",
-        "",
-        "[(M|D)] [ZEROFILL]",
-        "1",
-        "0",
-        "3",
-        "0",
-        "0",
-        "1",
-        "DOUBLE",
-        "-308",
-        "308",
-        "0",
-        "0",
-        "10"
+        "DOUBLE", "8", "17", "", "", "[(M,D)]", "1", "0", "3", "0", "0", "1", "DOUBLE", "-308",
+        "308", "0", "0", "10"
       },
       {
         "DOUBLE PRECISION",
@@ -2922,7 +2914,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "17",
         "",
         "",
-        "[(M,D)] [ZEROFILL]",
+        "[(M,D)]",
         "1",
         "0",
         "3",
@@ -2937,24 +2929,8 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "10"
       },
       {
-        "REAL",
-        "8",
-        "17",
-        "",
-        "",
-        "[(M,D)] [ZEROFILL]",
-        "1",
-        "0",
-        "3",
-        "0",
-        "0",
-        "1",
-        "REAL",
-        "-308",
-        "308",
-        "0",
-        "0",
-        "10"
+        "REAL", "8", "17", "", "", "[(M,D)]", "1", "0", "3", "0", "0", "1", "REAL", "-308", "308",
+        "0", "0", "10"
       },
       {
         "VARCHAR", "12", "255", "'", "'", "(M)", "1", "0", "3", "0", "0", "0", "VARCHAR", "0", "0",
@@ -2966,6 +2942,10 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
       },
       {
         "SET", "12", "64", "'", "'", "", "1", "0", "3", "0", "0", "0", "SET", "0", "0", "0", "0",
+        "10"
+      },
+      {
+        "YEAR", "5", "4", "'", "'", "", "1", "0", "3", "0", "0", "0", "YEAR", "0", "0", "0", "0",
         "10"
       },
       {
@@ -3015,8 +2995,53 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
         "0",
         "0",
         "10"
+      },
+      {
+        "VECTOR",
+        "1111",
+        "65532",
+        "'",
+        "'",
+        "[(M,<elementType>])]",
+        "1",
+        "1",
+        "3",
+        "\0",
+        "0",
+        "0",
+        "VECTOR",
+        "0",
+        "0",
+        "0",
+        "0",
+        "10"
+      },
+      {
+        "BSON",
+        "-4",
+        "2147483647",
+        "'",
+        "'",
+        "",
+        "1",
+        "1",
+        "3",
+        "0",
+        "0",
+        "0",
+        "BSON",
+        "0",
+        "0",
+        "0",
+        "0",
+        "10"
       }
     };
+
+    List<String[]> datalist = new ArrayList<>(Arrays.asList(baseData));
+    String[][] data = new String[datalist.size()][];
+    datalist.sort(Comparator.comparingInt((String[] m) -> Integer.parseInt(m[1])));
+    datalist.toArray(data);
 
     return CompleteResult.createResultSet(
         columnNames,

--- a/src/main/java/com/singlestore/jdbc/client/impl/ConnectionHelper.java
+++ b/src/main/java/com/singlestore/jdbc/client/impl/ConnectionHelper.java
@@ -348,7 +348,7 @@ public final class ConnectionHelper {
       TrustManager[] trustManagers =
           socketPlugin.getTrustManager(conf, context.getExceptionFactory());
       try {
-        SSLContext sslContext = SSLContext.getInstance("TLS");
+        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
         sslContext.init(
             socketPlugin.getKeyManager(conf, context.getExceptionFactory()), trustManagers, null);
         sslSocketFactory = sslContext.getSocketFactory();

--- a/src/main/java/com/singlestore/jdbc/export/ExceptionFactory.java
+++ b/src/main/java/com/singlestore/jdbc/export/ExceptionFactory.java
@@ -254,6 +254,15 @@ public class ExceptionFactory {
       return new SQLTimeoutException(msg, sqlState, errorCode);
     }
 
+    if ((errorCode == 4166 || errorCode == 3948 || errorCode == 1148) && !conf.allowLocalInfile()) {
+      return new SQLException(
+          "Local infile is disabled by connector. Enable `allowLocalInfile` to allow local infile"
+              + " commands",
+          sqlState,
+          errorCode,
+          cause);
+    }
+
     SQLException returnEx;
     String sqlClass = sqlState == null ? "42" : sqlState.substring(0, 2);
     switch (sqlClass) {

--- a/src/main/java/com/singlestore/jdbc/util/options/OptionAliases.java
+++ b/src/main/java/com/singlestore/jdbc/util/options/OptionAliases.java
@@ -18,7 +18,7 @@ public final class OptionAliases {
     OPTIONS_ALIASES.put("clientcertificatekeystorepassword", "keyStorePassword");
     OPTIONS_ALIASES.put("clientcertificatekeystoretype", "keyStoreType");
     OPTIONS_ALIASES.put("trustcertificatekeystoreurl", "trustStore");
-    OPTIONS_ALIASES.put("trustcertificatekeystorepassword", "keyStorePassword");
+    OPTIONS_ALIASES.put("trustcertificatekeystorepassword", "trustStorePassword");
     OPTIONS_ALIASES.put("trustcertificatekeystoretype", "trustStoreType");
     OPTIONS_ALIASES.put("nullcatalogmeanscurrent", "nullDatabaseMeansCurrent");
   }

--- a/src/test/java/com/singlestore/jdbc/integration/ConnectionTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/ConnectionTest.java
@@ -718,7 +718,7 @@ public class ConnectionTest extends Common {
     Common.assertThrowsContains(
         SQLException.class,
         () -> createCon("credentialType=JWT&user=jwt_user&password=" + jwt),
-        "unable to find valid certification path to requested target");
+        "No X509TrustManager found");
     Common.assertThrowsContains(
         SQLException.class,
         () -> createCon("credentialType=JWT&sslMode=trust&user=jwt_user&password=" + "invalid_jwt"),

--- a/src/test/java/com/singlestore/jdbc/integration/DataSourceTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/DataSourceTest.java
@@ -155,4 +155,21 @@ public class DataSourceTest extends Common {
     ds.setLoginTimeout(60);
     assertEquals(60, ds.getLoginTimeout());
   }
+
+  @Test
+  public void ensureConnectionClose() throws Exception {
+    SingleStoreDataSource datasource = new SingleStoreDataSource(mDefUrl);
+
+    java.sql.Connection c = datasource.getConnection();
+    assertFalse(c.isClosed());
+    c.close();
+    assertTrue(c.isClosed());
+
+    PooledConnection pc = datasource.getPooledConnection();
+    assertFalse(pc.getConnection().isClosed());
+    pc.getConnection().close();
+    assertFalse(pc.getConnection().isClosed());
+    pc.close();
+    assertTrue(pc.getConnection().isClosed());
+  }
 }

--- a/src/test/java/com/singlestore/jdbc/integration/LocalInfileTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/LocalInfileTest.java
@@ -130,14 +130,14 @@ public class LocalInfileTest extends Common {
           () ->
               stmt.execute(
                   "LOAD DATA LOCAL INFILE 'someFile' INTO TABLE LocalInfileInputStreamTest2 (id, test)"),
-          "LOAD DATA LOCAL is disabled by your client configuration");
+          "Local infile is disabled by connector. Enable `allowLocalInfile` to allow local infile commands");
       stmt.addBatch(
           "LOAD DATA LOCAL INFILE 'someFile' INTO TABLE LocalInfileInputStreamTest2 (id, test)");
       stmt.addBatch("SET UNIQUE_CHECKS=1");
       Common.assertThrowsContains(
           BatchUpdateException.class,
           () -> stmt.executeBatch(),
-          "LOAD DATA LOCAL is disabled by your client configuration");
+          "Local infile is disabled by connector. Enable `allowLocalInfile` to allow local infile commands");
     }
   }
 

--- a/src/test/java/com/singlestore/jdbc/integration/SslTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/SslTest.java
@@ -13,16 +13,18 @@ import com.singlestore.jdbc.Statement;
 import com.singlestore.jdbc.integration.tools.TcpProxy;
 import java.io.*;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 import java.sql.*;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.*;
 
 @DisplayName("SSL tests")
 public class SslTest extends Common {
-  private static Integer sslPort;
+  private static Integer sslPort = port;
   private static String baseOptions = "&user=serverAuthUser&password=!Passw0rd3Works";
   private static final String baseMutualOptions = "&user=mutualAuthUser&password=!Passw0rd3Works";
 
@@ -40,11 +42,6 @@ public class SslTest extends Common {
 
     Statement stmt = sharedConn.createStatement();
     stmt.execute("FLUSH PRIVILEGES");
-    sslPort =
-        System.getenv("TEST_MAXSCALE_TLS_PORT") == null
-                || System.getenv("TEST_MAXSCALE_TLS_PORT").isEmpty()
-            ? null
-            : Integer.valueOf(System.getenv("TEST_MAXSCALE_TLS_PORT"));
   }
 
   public static String retrieveCertificatePath() throws Exception {
@@ -62,7 +59,7 @@ public class SslTest extends Common {
       }
     }
     if (serverCertificatePath == null) {
-      serverCertificatePath = checkFileExists("../../ssl/server.crt");
+      serverCertificatePath = checkFileExists("src/test/resources/ssl/server.crt");
     }
     return serverCertificatePath;
   }
@@ -222,6 +219,125 @@ public class SslTest extends Common {
             sslPort)) {
       assertNotNull(getSslVersion(con));
     }
+  }
+
+  public static String retrieveCaCertificatePath() throws Exception {
+    String serverCertificatePath = checkFileExists(System.getProperty("serverCertificatePath"));
+    if (serverCertificatePath == null) {
+      serverCertificatePath = checkFileExists(System.getenv("TEST_DB_SERVER_CA_CERT"));
+    }
+
+    if (serverCertificatePath == null) {
+      serverCertificatePath = checkFileExists("src/test/resources/ssl/ca.crt");
+    }
+    return serverCertificatePath;
+  }
+
+  @Test
+  public void trustStoreParameter() throws Throwable {
+    String serverCertPath = retrieveCertificatePath();
+    String caCertPath = retrieveCaCertificatePath();
+    Assumptions.assumeTrue(serverCertPath != null, "Canceled, server certificate not provided");
+
+    KeyStore ks = KeyStore.getInstance("jks");
+    char[] pwdArray = "myPwd0".toCharArray();
+    ks.load(null, pwdArray);
+
+    File temptrustStoreFile = File.createTempFile("newKeyStoreFileName", ".jks");
+
+    KeyStore ks2 = KeyStore.getInstance("pkcs12");
+    ks2.load(null, pwdArray);
+    File temptrustStoreFile2 = File.createTempFile("newKeyStoreFileName", ".pkcs12");
+
+    try (InputStream inStream = new File(serverCertPath).toURI().toURL().openStream()) {
+      CertificateFactory cf = CertificateFactory.getInstance("X.509");
+      Collection<? extends Certificate> serverCertList = cf.generateCertificates(inStream);
+      List<Certificate> certs = new ArrayList<>();
+      for (Iterator<? extends Certificate> iter = serverCertList.iterator(); iter.hasNext(); ) {
+        certs.add(iter.next());
+      }
+      if (caCertPath != null) {
+        try (InputStream inStream2 = new File(caCertPath).toURI().toURL().openStream()) {
+          CertificateFactory cf2 = CertificateFactory.getInstance("X.509");
+          Collection<? extends Certificate> caCertList = cf2.generateCertificates(inStream2);
+          for (Iterator<? extends Certificate> iter = caCertList.iterator(); iter.hasNext(); ) {
+            certs.add(iter.next());
+          }
+        }
+      }
+      for (Certificate cert : certs) {
+        ks.setCertificateEntry(hostname, cert);
+        ks2.setCertificateEntry(hostname, cert);
+      }
+
+      try (FileOutputStream fos = new FileOutputStream(temptrustStoreFile.getPath())) {
+        ks.store(fos, pwdArray);
+      }
+      try (FileOutputStream fos = new FileOutputStream(temptrustStoreFile2.getPath())) {
+        ks2.store(fos, pwdArray);
+      }
+    }
+
+    // certificate path, like  /path/certificate.crt
+    try (Connection con =
+        createCon(
+            baseOptions
+                + "&sslMode=VERIFY_CA&trustStore="
+                + temptrustStoreFile
+                + "&trustStoreType=jks&trustStorePassword=myPwd0",
+            sslPort)) {
+      assertNotNull(getSslVersion(con));
+    }
+
+    // with alias
+    try (Connection con =
+        createCon(
+            baseOptions
+                + "&sslMode=VERIFY_CA&trustCertificateKeystoreUrl="
+                + temptrustStoreFile
+                + "&trustCertificateKeyStoretype=jks&trustCertificateKeystorePassword=myPwd0",
+            sslPort)) {
+      assertNotNull(getSslVersion(con));
+    }
+    assertThrowsContains(
+        SQLException.class,
+        () ->
+            createCon(
+                baseOptions
+                    + "&sslMode=VERIFY_CA&trustStore="
+                    + temptrustStoreFile
+                    + "&trustStoreType=jks&trustStorePassword=wrongPwd",
+                sslPort),
+        "Failed load keyStore");
+    assertThrowsContains(
+        SQLException.class,
+        () ->
+            createCon(
+                baseOptions
+                    + "&sslMode=VERIFY_CA&trustCertificateKeystoreUrl="
+                    + temptrustStoreFile
+                    + "&trustCertificateKeyStoretype=jks&trustCertificateKeystorePassword=wrongPwd",
+                sslPort),
+        "Failed load keyStore");
+    try (Connection con =
+        createCon(
+            baseOptions
+                + "&sslMode=VERIFY_CA&trustStore="
+                + temptrustStoreFile2
+                + "&trustStoreType=pkcs12&trustStorePassword=myPwd0",
+            sslPort)) {
+      assertNotNull(getSslVersion(con));
+    }
+    assertThrowsContains(
+        SQLException.class,
+        () ->
+            createCon(
+                baseOptions
+                    + "&sslMode=VERIFY_CA&trustStore="
+                    + temptrustStoreFile2
+                    + "&trustStoreType=pkcs12&trustStorePassword=wrongPwd",
+                sslPort),
+        "Failed load keyStore");
   }
 
   private String getServerCertificate(String serverCertPath) throws SQLException {


### PR DESCRIPTION
- DatabaseMetaData.getTypeInfo add missed types
- Set TLSv1.2 as base reference.
- Reactor DefaultTlsSocketPlugin.
- Add truststore test.