### PR TITLE
PLAT-7414 Rollback additional aliases for truststore parameters

### DIFF
--- a/src/main/java/com/singlestore/jdbc/plugin/tls/main/DefaultTlsSocketPlugin.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/tls/main/DefaultTlsSocketPlugin.java
@@ -191,9 +191,9 @@ public class DefaultTlsSocketPlugin implements TlsSocketPlugin {
               "08000",
               generalSecurityEx);
         }
-      }
-      if (trustManager == null) {
-        throw new SQLException("No X509TrustManager found");
+        if (trustManager == null) {
+          throw new SQLException("No X509TrustManager found");
+        }
       }
     }
     return trustManager;

--- a/src/main/java/com/singlestore/jdbc/util/options/OptionAliases.java
+++ b/src/main/java/com/singlestore/jdbc/util/options/OptionAliases.java
@@ -17,9 +17,6 @@ public final class OptionAliases {
     OPTIONS_ALIASES.put("clientcertificatekeystoreurl", "keyStore");
     OPTIONS_ALIASES.put("clientcertificatekeystorepassword", "keyStorePassword");
     OPTIONS_ALIASES.put("clientcertificatekeystoretype", "keyStoreType");
-    OPTIONS_ALIASES.put("trustcertificatekeystoreurl", "trustStore");
-    OPTIONS_ALIASES.put("trustcertificatekeystorepassword", "trustStorePassword");
-    OPTIONS_ALIASES.put("trustcertificatekeystoretype", "trustStoreType");
     OPTIONS_ALIASES.put("nullcatalogmeanscurrent", "nullDatabaseMeansCurrent");
   }
 }


### PR DESCRIPTION
Rollback additional aliases because they are used by DBeaver, and they break compatibility, forcing users to specify the trust store manually instead of using the system trust store.