### PR TITLE
PLAT-7511 Introduce a new JDBC connection string parameter to enable …

### DIFF
--- a/src/main/java/com/singlestore/jdbc/Configuration.java
+++ b/src/main/java/com/singlestore/jdbc/Configuration.java
@@ -150,6 +150,7 @@ public class Configuration {
   private String connectionAttributes;
   private String servicePrincipalName;
   private String jaasApplicationName;
+  private Boolean cacheJaasLoginContext;
 
   // meta
   private boolean blankTableNameMeta;
@@ -397,6 +398,7 @@ public class Configuration {
   private void initializeAdditionalConfig(Builder builder) {
     this.servicePrincipalName = builder.servicePrincipalName;
     this.jaasApplicationName = builder.jaasApplicationName;
+    this.cacheJaasLoginContext = builder.cacheJaasLoginContext;
     this.defaultFetchSize = builder.defaultFetchSize != null ? builder.defaultFetchSize : 0;
     this.tlsSocketType = builder.tlsSocketType;
     this.maxAllowedPacket = builder.maxAllowedPacket;
@@ -499,6 +501,7 @@ public class Configuration {
             .connectionAttributes(this.connectionAttributes)
             .servicePrincipalName(this.servicePrincipalName)
             .jaasApplicationName(this.jaasApplicationName)
+            .cacheJaasLoginContext(this.cacheJaasLoginContext)
             .blankTableNameMeta(this.blankTableNameMeta)
             .tinyInt1isBit(this.tinyInt1isBit)
             .transformedBitIsBoolean(this.transformedBitIsBoolean)
@@ -1489,6 +1492,16 @@ public class Configuration {
     return jaasApplicationName;
   }
 
+  /**
+   * When using GSSAPI authentication, explicitly enable or disable caching for the JAAS Login
+   * Context.
+   *
+   * @return cacheJaasLoginContext forced value
+   */
+  public Boolean cacheJaasLoginContext() {
+    return cacheJaasLoginContext;
+  }
+
   public int defaultFetchSize() {
     return defaultFetchSize;
   }
@@ -1912,6 +1925,7 @@ public class Configuration {
     private String connectionAttributes;
     private String servicePrincipalName;
     private String jaasApplicationName;
+    private Boolean cacheJaasLoginContext;
 
     // meta
     private Boolean blankTableNameMeta;
@@ -2391,6 +2405,11 @@ public class Configuration {
 
     public Builder jaasApplicationName(String jaasApplicationName) {
       this.jaasApplicationName = nullOrEmpty(jaasApplicationName);
+      return this;
+    }
+
+    public Builder cacheJaasLoginContext(Boolean cacheJaasLoginContext) {
+      this.cacheJaasLoginContext = cacheJaasLoginContext;
       return this;
     }
 

--- a/src/main/java/com/singlestore/jdbc/plugin/authentication/addon/SendGssApiAuthPacket.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/authentication/addon/SendGssApiAuthPacket.java
@@ -72,7 +72,8 @@ public class SendGssApiAuthPacket implements AuthenticationPlugin {
       mechanisms = "Kerberos";
     }
 
-    gssapiAuth.authenticate(out, in, servicePrincipalName, jaasApplicationName, mechanisms);
+    gssapiAuth.authenticate(
+        context, out, in, servicePrincipalName, jaasApplicationName, mechanisms);
 
     return in.readReusablePacket();
   }

--- a/src/main/java/com/singlestore/jdbc/plugin/authentication/addon/gssapi/GssapiAuth.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/authentication/addon/gssapi/GssapiAuth.java
@@ -5,6 +5,7 @@
 
 package com.singlestore.jdbc.plugin.authentication.addon.gssapi;
 
+import com.singlestore.jdbc.client.Context;
 import com.singlestore.jdbc.client.socket.Reader;
 import com.singlestore.jdbc.client.socket.Writer;
 import java.io.IOException;
@@ -24,6 +25,7 @@ public interface GssapiAuth {
    * @throws SQLException for any other type of errors
    */
   void authenticate(
+      Context ctx,
       Writer writer,
       Reader in,
       String servicePrincipalName,

--- a/src/main/java/com/singlestore/jdbc/plugin/authentication/addon/gssapi/WindowsNativeSspiAuthentication.java
+++ b/src/main/java/com/singlestore/jdbc/plugin/authentication/addon/gssapi/WindowsNativeSspiAuthentication.java
@@ -5,6 +5,7 @@
 
 package com.singlestore.jdbc.plugin.authentication.addon.gssapi;
 
+import com.singlestore.jdbc.client.Context;
 import com.singlestore.jdbc.client.ReadableByteBuf;
 import com.singlestore.jdbc.client.socket.Reader;
 import com.singlestore.jdbc.client.socket.Writer;
@@ -27,6 +28,7 @@ public class WindowsNativeSspiAuthentication implements GssapiAuth {
    * @throws IOException if socket error
    */
   public void authenticate(
+      final Context ctx,
       final Writer out,
       final Reader in,
       final String servicePrincipalName,

--- a/src/main/resources/driver.properties
+++ b/src/main/resources/driver.properties
@@ -27,6 +27,7 @@ connectionAttributes=When performance_schema is active, permit to send server so
 includeThreadDumpInDeadlockExceptions=add thread dump to exception trace when having a deadlock exception.
 servicePrincipalName=When using GSSAPI authentication, use this value as the Service Principal Name (SPN) instead of the one defined for the user account on the database server.
 jaasApplicationName==When using GSSAPI authentication, this indicates the entry name to use in the JAAS Login Configuration File
+cacheJaasLoginContext=When using GSSAPI authentication, this indicates whether to cache the JAAS Login Context.
 defaultFetchSize=The driver will call setFetchSize(n) with this value on all newly-created Statements. Default: 0.
 tlsSocketType=Indicate the TLS com.singlestore.jdbc.tls.TlsSocketPlugin plugin type to use. Plugin must be present in classpath
 maxQuerySizeToLog=Only the first characters corresponding to this options size will be displayed in logs. Default: 1024


### PR DESCRIPTION
…jaas Login Context caching

* By default, if the user does not specify a custom java.security.auth.login.config, caching is enabled.
* If a custom configuration is provided, caching is disabled by default.
* A new connection string parameter, cacheJaasLoginContext=true|false, allows explicitly enabling or disabling JAAS Login Context caching for custom and default configuration.