### PR TITLE
test: fix flaky testPoolFailover in PooledConnectionTest

### DIFF
--- a/src/test/java/com/singlestore/jdbc/integration/PooledConnectionTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/PooledConnectionTest.java
@@ -98,7 +98,7 @@ public class PooledConnectionTest extends Common {
 
     try (SingleStorePoolDataSource ds =
         new SingleStorePoolDataSource(
-            url + "poolValidMinDelay=1&connectTimeout=50&maxPoolSize=1")) {
+            url + "poolValidMinDelay=1&connectTimeout=500&maxPoolSize=1")) {
 
       PooledConnection pc = ds.getPooledConnection();
       pc.getConnection().isValid(1);


### PR DESCRIPTION
## Summary
- Increase `connectTimeout` from 50ms to 500ms in `testPoolFailover` to prevent the initial connection through the TCP proxy from timing out in CI environments
- Fixes failure seen in https://github.com/memsql/S2-JDBC-Connector/actions/runs/23501719131/job/68398363878

## Test plan
- [x] CI passes with the updated timeout value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that relaxes timing to avoid intermittent CI timeouts; no production code behavior is modified.
> 
> **Overview**
> **Stabilizes `testPoolFailover`** by increasing the `connectTimeout` used when creating a `SingleStorePoolDataSource` through the TCP proxy (50ms → 500ms), reducing intermittent timeouts in slower CI environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892bf9c0df49bf914abb29e531521b25f6cf708c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->