### PR TITLE
chore: bump version to 1.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SingleStore Change Log
 
+## [1.2.10](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v1.2.10)
+* Add socksProxyHost and socksProxyPort connection parameters (#53)
+* Add scheduled and manual triggering for CI tests
+* Update dependencies to fix security vulnerabilities (#59)
+
 ## [1.2.9](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v1.2.9)
 * [PLAT-7700] Simplified LOAD DATA LOCAL INFILE statement parsing
 * [PLAT-7493] Throw an exception on overflow time value

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>singlestore-jdbc-client</artifactId>
     <packaging>jar</packaging>
     <name>singlestore-jdbc-client</name>
-    <version>1.2.9</version>
+    <version>1.2.10</version>
     <description>SingleStore JDBC Driver</description>
     <url>https://github.com/memsql/S2-JDBC-Connector</url>
 
@@ -55,7 +55,7 @@
         <url>git://git@github.com:memsql/S2-JDBC-Connector.git</url>
         <connection>scm:git:git@github.com:memsql/S2-JDBC-Connector.git</connection>
         <developerConnection>scm:git:git@github.com:memsql/S2-JDBC-Connector.git</developerConnection>
-        <tag>singlestore-jdbc-client-1.2.9</tag>
+        <tag>singlestore-jdbc-client-1.2.10</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates `pom.xml` version/SCM tag and documents the 1.2.10 release in `CHANGELOG.md` without changing runtime code.
> 
> **Overview**
> Bumps the driver release from **1.2.9** to **1.2.10** by updating `pom.xml` (project version and SCM tag).
> 
> Adds a new `CHANGELOG.md` entry for `1.2.10`, noting SOCKS proxy connection parameters, CI test triggering updates, and dependency vulnerability fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 876c5ca863a8e70523553aba7d9be72c9f150231. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->