### PR TITLE
chore: create GitHub Release in release.yml and add release skills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -49,3 +51,17 @@ jobs:
       - name: Release to Maven Central
         if: ${{ success() }}
         run: mvn -s ci/settings.xml clean deploy -DskipTests -Dsonatype.username=${{ secrets.SONATYPE_USER }} -Dsonatype.password=${{ secrets.SONATYPE_PASSWORD }}
+      - name: Derive release version
+        if: ${{ success() }}
+        run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+      - name: Create GitHub Release
+        if: ${{ success() }}
+        uses: softprops/action-gh-release@v2
+        with:
+          name: SingleStore JDBC Driver ${{ env.RELEASE_VERSION }}
+          prerelease: false
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            target/singlestore-jdbc-client-${{ env.RELEASE_VERSION }}-browser-sso-uber.jar
+            target/singlestore-jdbc-client-${{ env.RELEASE_VERSION }}.jar

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .idea
 /mariadb-java-client.iml
 scripts/ssl/*
+
+.claude/*

--- a/ai/skills/prepare-release.md
+++ b/ai/skills/prepare-release.md
@@ -1,0 +1,21 @@
+Create a new release for version $ARGUMENTS.
+
+Follow these steps:
+
+1. **Determine changelog entries**: Run `git log` to find all commits since the last release tag. Summarize meaningful changes (features, bug fixes, dependency updates) for the changelog. Skip test-only changes (commits prefixed with `test:`).
+
+2. **Update pom.xml**: Change the `<version>` field and the `<tag>` field in the `<scm>` section to the new version. The tag format is `singlestore-jdbc-client-<version>`.
+
+3. **Update CHANGELOG.md**: Add a new section at the top (below the `# SingleStore Change Log` header) with the format:
+   ```
+   ## [<version>](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v<version>)
+   * <change description> (#PR)
+   ```
+
+4. **Create a branch**: `release-<version>`
+
+5. **Show the diff** to the user for review before committing.
+
+6. **After user confirms**: Commit with message `chore: bump version to <version>` and body `Incremented version, updated changelog`.
+
+7. **Push and open PR** with title `chore: bump version to <version>` and body `Incremented version, updated changelog`.

--- a/ai/skills/publish-release.md
+++ b/ai/skills/publish-release.md
@@ -1,0 +1,17 @@
+Publish the release for version $ARGUMENTS.
+
+Follow these steps:
+
+1. **Check CI status**: Run `gh pr checks` on the release PR to verify all checks are green. If any checks are failing, report the failures and stop.
+
+2. **Check PR approval**: Run `gh pr view` to verify the PR has at least one approving review. If not approved, report and stop.
+
+3. **Merge the PR**: Merge the release PR using `gh pr merge --squash`.
+
+4. **Push the tag**: After merging, checkout master, pull latest, and create + push an annotated tag `v<version>` pointing at the merge commit.
+   ```
+   git tag -a v<version> -m "Release <version>"
+   git push origin v<version>
+   ```
+
+5. **Confirm** the tag was pushed successfully.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the tag-triggered release workflow to publish GitHub Releases and upload built JAR artifacts, including granting the job `contents: write` permissions. Risk is moderate because it affects the release pipeline and could fail releases or publish incorrect artifacts if version/filenames don’t match.
> 
> **Overview**
> The release GitHub Action now **derives the version from the `v*` tag** and **creates a GitHub Release** after deploying to Maven Central, uploading the built driver JARs as release assets.
> 
> Adds operational docs in `ai/skills/prepare-release.md` and `ai/skills/publish-release.md` for preparing and publishing releases, and updates `.gitignore` to exclude `.claude/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05742de3642f15be3b7e494c7588b003ded37fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->