### PR TITLE
chore: ignore dependency-reduced-pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 .idea
 /mariadb-java-client.iml
 scripts/ssl/*
+dependency-reduced-pom.xml
 
 .claude/*


### PR DESCRIPTION
## Summary
- Add `dependency-reduced-pom.xml` (generated by maven-shade-plugin) to `.gitignore` so the build artifact stops showing up as untracked.

## Test plan
- [x] Run a build that triggers the shade plugin and confirm `git status` stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects git ignore rules; no runtime or build logic changes.
> 
> **Overview**
> Updates `.gitignore` to exclude `dependency-reduced-pom.xml`, preventing the Maven Shade plugin’s generated build artifact from appearing as an untracked file in `git status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4daf8bbbef5f0204c61d951519d167ced73a93f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->