### PR TITLE
chore: bump version to 1.2.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
           path: target/surefire-reports
       - store_artifacts: # store the jar as an artifact
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: target/singlestore-jdbc-client-1.2.11.jar
+          path: target/singlestore-jdbc-client-1.2.12.jar
       - store_artifacts:
-          path: target/singlestore-jdbc-client-1.2.11-browser-sso-uber.jar
+          path: target/singlestore-jdbc-client-1.2.12-browser-sso-uber.jar
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
   test_jdk:
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingleStore Change Log
 
+## [1.2.12](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v1.2.12)
+* Kerberos constrained delegation: `gssCredential` connection property and `requestCredentialDelegation` option for GSSAPI authentication
+* Add Docker-based Kerberos/GSSAPI end-to-end test scripts (#67)
+* Stabilize flaky integration tests (#69, #71, #73)
+* Ignore `dependency-reduced-pom.xml` (#68)
+
 ## [1.2.11](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v1.2.11)
 * [PLAT-7862] Added hostNameInCertificate option
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SingleStore JDBC Driver
 
-## Version: 1.2.11
+## Version: 1.2.12
 
 SingleStore JDBC Driver is a JDBC 4.2 compatible driver, used to connect applications developed in Java to SingleStore and MySQL databases. SingleStore JDBC Driver is LGPL licensed.
 
@@ -14,7 +14,7 @@ The driver (jar) can be downloaded from maven :
 <dependency>
 	<groupId>com.singlestore</groupId>
 	<artifactId>singlestore-jdbc-client</artifactId>
-	<version>1.2.11</version>
+	<version>1.2.12</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>singlestore-jdbc-client</artifactId>
     <packaging>jar</packaging>
     <name>singlestore-jdbc-client</name>
-    <version>1.2.11</version>
+    <version>1.2.12</version>
     <description>SingleStore JDBC Driver</description>
     <url>https://github.com/memsql/S2-JDBC-Connector</url>
 
@@ -55,7 +55,7 @@
         <url>git://git@github.com:memsql/S2-JDBC-Connector.git</url>
         <connection>scm:git:git@github.com:memsql/S2-JDBC-Connector.git</connection>
         <developerConnection>scm:git:git@github.com:memsql/S2-JDBC-Connector.git</developerConnection>
-        <tag>singlestore-jdbc-client-1.2.11</tag>
+        <tag>singlestore-jdbc-client-1.2.12</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Incremented version, updated changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/documentation and CI artifact naming changes only; no runtime code paths are modified.
> 
> **Overview**
> Bumps the JDBC driver release from `1.2.11` to `1.2.12` across build and documentation.
> 
> Updates `pom.xml` version and SCM tag, adjusts CircleCI artifact names to the new jar versions, and adds the `1.2.12` entry to `CHANGELOG.md` (Kerberos constrained delegation, new Kerberos/GSSAPI E2E test scripts, and test stability fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a42d3f2f9ae5c09942b01d373d78c0375bec7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->