### PR TITLE
chore: bump version to 1.2.12-beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
           path: target/surefire-reports
       - store_artifacts: # store the jar as an artifact
           # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: target/singlestore-jdbc-client-1.2.11.jar
+          path: target/singlestore-jdbc-client-1.2.12-beta.jar
       - store_artifacts:
-          path: target/singlestore-jdbc-client-1.2.11-browser-sso-uber.jar
+          path: target/singlestore-jdbc-client-1.2.12-beta-browser-sso-uber.jar
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
   test_jdk:
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SingleStore Change Log
 
+## [1.2.12-beta](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v1.2.12-beta)
+* Kerberos constrained delegation: `gssCredential` connection property and `requestCredentialDelegation` option for GSSAPI authentication
+* Add Docker-based Kerberos/GSSAPI end-to-end test scripts (#67)
+* Stabilize flaky integration tests (#69, #71, #73)
+
 ## [1.2.11](https://github.com/memsql/S2-JDBC-Connector/releases/tag/v1.2.11)
 * [PLAT-7862] Added hostNameInCertificate option
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SingleStore JDBC Driver
 
-## Version: 1.2.11
+## Version: 1.2.12-beta
 
 SingleStore JDBC Driver is a JDBC 4.2 compatible driver, used to connect applications developed in Java to SingleStore and MySQL databases. SingleStore JDBC Driver is LGPL licensed.
 
@@ -14,7 +14,7 @@ The driver (jar) can be downloaded from maven :
 <dependency>
 	<groupId>com.singlestore</groupId>
 	<artifactId>singlestore-jdbc-client</artifactId>
-	<version>1.2.11</version>
+	<version>1.2.12-beta</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>singlestore-jdbc-client</artifactId>
     <packaging>jar</packaging>
     <name>singlestore-jdbc-client</name>
-    <version>1.2.11</version>
+    <version>1.2.12-beta</version>
     <description>SingleStore JDBC Driver</description>
     <url>https://github.com/memsql/S2-JDBC-Connector</url>
 
@@ -55,7 +55,7 @@
         <url>git://git@github.com:memsql/S2-JDBC-Connector.git</url>
         <connection>scm:git:git@github.com:memsql/S2-JDBC-Connector.git</connection>
         <developerConnection>scm:git:git@github.com:memsql/S2-JDBC-Connector.git</developerConnection>
-        <tag>singlestore-jdbc-client-1.2.11</tag>
+        <tag>singlestore-jdbc-client-1.2.12-beta</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily a version/metadata and documentation update; behavior is unchanged aside from CI artifact naming and release tagging.
> 
> **Overview**
> Bumps the JDBC driver release version from `1.2.11` to `1.2.12-beta` across build metadata and docs.
> 
> Updates Maven `pom.xml` (project version and SCM tag), refreshes CircleCI artifact paths to match the new jar names, and adds a `1.2.12-beta` section to `CHANGELOG.md` describing the release highlights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f83f86d50bb1297dd984a72b1d6bda53cfcb97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->