### PR TITLE
test: fix flaky ensureClosed in PoolDataSourceTest on SS 9.1

### DIFF
--- a/src/test/java/com/singlestore/jdbc/integration/PoolDataSourceTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/PoolDataSourceTest.java
@@ -574,19 +574,21 @@ public class PoolDataSourceTest extends Common {
     connectionAppender.shutdown();
     connectionAppender.awaitTermination(30, TimeUnit.SECONDS);
     assertTrue(threadIds.size() <= 9, "connection ids must be less than 9 : " + threadIds.size());
-    Pools.close("PoolTest");
+    Pools.close("PoolEnsureUsingPool");
   }
 
   @Test
   public void ensureClosed() throws Throwable {
     Thread.sleep(2000); // ensure that previous close are effective
     int initialConnection = getCurrentConnections();
+    Set<Long> poolConnectionIds = new HashSet<>();
 
     try (SingleStorePoolDataSource pool =
         new SingleStorePoolDataSource(mDefUrl + "&maxPoolSize=10&minPoolSize=3")) {
 
       try (Connection connection = pool.getConnection()) {
         connection.isValid(10_000);
+        poolConnectionIds.add(((com.singlestore.jdbc.Connection) connection).getThreadId());
       }
 
       assertTrue(getCurrentConnections() > initialConnection);
@@ -594,17 +596,43 @@ public class PoolDataSourceTest extends Common {
       // reuse IdleConnection
       try (Connection connection = pool.getConnection()) {
         connection.isValid(10_000);
+        poolConnectionIds.add(((com.singlestore.jdbc.Connection) connection).getThreadId());
       }
 
       Thread.sleep(500);
       assertTrue(getCurrentConnections() > initialConnection);
     }
     // wait for connections to close, may take a while on some server versions
+    long waitStart = System.currentTimeMillis();
+    int finalConnection = getCurrentConnections();
+    boolean converged = false;
     for (int i = 0; i < 10; i++) {
       Thread.sleep(500);
-      if (getCurrentConnections() <= initialConnection) break;
+      finalConnection = getCurrentConnections();
+      if (finalConnection <= initialConnection) {
+        converged = true;
+        break;
+      }
     }
-    assertEquals(initialConnection, getCurrentConnections());
+    if (!converged) {
+      fail(
+          "connections did not converge within "
+              + (System.currentTimeMillis() - waitStart)
+              + "ms; expected <= "
+              + initialConnection
+              + " connections, got "
+              + finalConnection);
+    }
+    assertTrue(
+        finalConnection <= initialConnection,
+        "expected <= " + initialConnection + " connections, got " + finalConnection);
+
+    Set<Long> remainingConnectionIds = getCurrentConnectionIds();
+    for (Long poolConnectionId : poolConnectionIds) {
+      assertFalse(
+          remainingConnectionIds.contains(poolConnectionId),
+          "pooled connection is still active: " + poolConnectionId);
+    }
   }
 
   @Test
@@ -665,6 +693,17 @@ public class PoolDataSourceTest extends Common {
 
     } catch (SQLException e) {
       return -1;
+    }
+  }
+
+  public static Set<Long> getCurrentConnectionIds() throws SQLException {
+    try (Statement stmt = sharedConn.createStatement();
+        ResultSet rs = stmt.executeQuery("SHOW PROCESSLIST")) {
+      Set<Long> connectionIds = new HashSet<>();
+      while (rs.next()) {
+        connectionIds.add(rs.getLong(1));
+      }
+      return connectionIds;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the CI failure in [Test run #158](https://github.com/memsql/S2-JDBC-Connector/actions/runs/28760332938/job/85274492418) (`test (9.1)`), where `PoolDataSourceTest.ensureClosed` failed with:

```
org.opentest4j.AssertionFailedError: expected: <9> but was: <8>
```

## Root cause

`ensureClosed` polls until `Threads_connected` drops to or below the initial baseline, but then asserts **exact** equality. On SingleStore 9.1, connections from earlier tests (notably `ensureUsingPool`) can close asynchronously during the wait window, so the final count can legitimately be **below** the baseline even though the pool under test has shut down cleanly.

Additionally, `ensureUsingPool` created a pool named `PoolEnsureUsingPool` but called `Pools.close("PoolTest")`, leaving that pool open and contributing to timing-dependent connection counts.

## Changes

- Replace strict `assertEquals(initialConnection, …)` with `assertTrue(finalConnection <= initialConnection)` after the polling loop
- Track pooled connection thread IDs and assert they are no longer present in `SHOW PROCESSLIST`
- Fix `ensureUsingPool` teardown to call `Pools.close("PoolEnsureUsingPool")`

## Testing

- `mvn test -Dtest=PreserveInstantsConfigurationTest` (unit tests compile and pass)
- Integration tests require a SingleStore cluster (not available in this environment); CI should validate on SS 9.1
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-109290b8-4f84-4b2d-8498-f2dfaa66c177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-109290b8-4f84-4b2d-8498-f2dfaa66c177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

