### PR TITLE
build: update dependencies to fix Dependabot security alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <logback.version>1.5.32</logback.version>
+        <logback.version>1.5.38</logback.version>
         <logback-java8.version>1.3.16</logback-java8.version>
         <jacoco.version>0.8.12</jacoco.version>
         <waffle-jna.version>3.3.0</waffle-jna.version>
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.42.13</version>
+                <version>2.50.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -363,7 +363,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.21.2</version>
+            <version>2.21.5</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Bumps `software.amazon.awssdk:bom` `2.42.13` → `2.50.3` (brings Netty `4.1.136.Final`, fixing Netty CVE alerts)
- Bumps `jackson-datatype-jsr310` `2.21.2` → `2.21.5` (jackson-databind patched versions)
- Bumps `logback.version` `1.5.32` → `1.5.38` (logback-core patched versions)

Addresses open Dependabot alerts for `io.netty:*`, `jackson-databind`, and `logback-core`:
https://github.com/memsql/S2-JDBC-Connector/security/dependabot

## Test plan
- [ ] Confirm CI passes
- [ ] After merge, verify Dependabot alerts are resolved / auto-dismissed


Made with [Cursor](https://cursor.com)