### PR TITLE
test: fix address already in use in the browser auth test

### DIFF
--- a/src/test/java/com/singlestore/jdbc/integration/BrowserAuthTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/BrowserAuthTest.java
@@ -506,6 +506,7 @@ public class BrowserAuthTest extends Common {
 
     public void stop() {
       server.stop(0);
+      MockBrowserCredentialPlugin.resetBaseURL();
     }
   }
 }

--- a/src/test/java/com/singlestore/jdbc/integration/BrowserAuthTest.java
+++ b/src/test/java/com/singlestore/jdbc/integration/BrowserAuthTest.java
@@ -6,6 +6,7 @@ package com.singlestore.jdbc.integration;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.singlestore.jdbc.Statement;
+import com.singlestore.jdbc.integration.util.MockBrowserCredentialPlugin;
 import com.singlestore.jdbc.plugin.credential.CredentialPluginLoader;
 import com.singlestore.jdbc.plugin.credential.browser.BrowserCredentialPlugin;
 import com.singlestore.jdbc.plugin.credential.browser.TokenWaiterServer;
@@ -453,7 +454,7 @@ public class BrowserAuthTest extends Common {
     public MockHttpServer(
         String jwt, boolean shouldHaveEmail, int expectedPackets, int shouldReceiveErrorWithCode)
         throws IOException {
-      server = HttpServer.create(new InetSocketAddress(18087), 0);
+      server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
       packetsLeft = expectedPackets;
 
       String path = "/";
@@ -499,6 +500,8 @@ public class BrowserAuthTest extends Common {
             }
           });
       server.start();
+      MockBrowserCredentialPlugin.setBaseURL(
+          "http://127.0.0.1:" + server.getAddress().getPort() + path);
     }
 
     public void stop() {

--- a/src/test/java/com/singlestore/jdbc/integration/util/MockBrowserCredentialPlugin.java
+++ b/src/test/java/com/singlestore/jdbc/integration/util/MockBrowserCredentialPlugin.java
@@ -16,7 +16,13 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.HttpClients;
 
 public class MockBrowserCredentialPlugin extends BrowserCredentialPlugin {
-  private static final String baseURL = "http://127.0.0.1:18087";
+  // The mock SSO server listens on an ephemeral port, so tests publish its address here before
+  // connecting. Defaults to a port nobody listens on, which is what timeout tests expect.
+  private static volatile String baseURL = "http://127.0.0.1:18087";
+
+  public static void setBaseURL(String url) {
+    baseURL = url;
+  }
 
   @Override
   public String type() {

--- a/src/test/java/com/singlestore/jdbc/integration/util/MockBrowserCredentialPlugin.java
+++ b/src/test/java/com/singlestore/jdbc/integration/util/MockBrowserCredentialPlugin.java
@@ -16,12 +16,19 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.HttpClients;
 
 public class MockBrowserCredentialPlugin extends BrowserCredentialPlugin {
+  // A port outside the ephemeral range, so that no other test server can end up listening on it.
+  private static final String UNREACHABLE_BASE_URL = "http://127.0.0.1:18087";
+
   // The mock SSO server listens on an ephemeral port, so tests publish its address here before
-  // connecting. Defaults to a port nobody listens on, which is what timeout tests expect.
-  private static volatile String baseURL = "http://127.0.0.1:18087";
+  // connecting. Defaults to an unreachable URL, which is what timeout tests expect.
+  private static volatile String baseURL = UNREACHABLE_BASE_URL;
 
   public static void setBaseURL(String url) {
     baseURL = url;
+  }
+
+  public static void resetBaseURL() {
+    baseURL = UNREACHABLE_BASE_URL;
   }
 
   @Override


### PR DESCRIPTION
Fix for intermittent filures like https://github.com/memsql/S2-JDBC-Connector/actions/runs/31027170624/job/92378554970#step:7:19297